### PR TITLE
Purge availability cache on updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FP-Prenotazioni-Ristorante-PRO
 
-**Version:** 10.0.0  
+**Version:** 10.0.2
 **Author:** Francesco Passeri  
 **License:** GPLv2 or later
 
@@ -286,7 +286,13 @@ update_post_meta($post_id, 'rbf_source_bucket', $src['bucket']);
 
 ## 📋 Changelog
 
-### Version 10.0.0 (Current)
+### Version 10.0.2 (Current)
+- ♻️ Clear cached availability when plugin is updated or settings change.
+
+### Version 10.0.1
+- 🐛 Fix: Availability check returning no time slots when new settings were missing.
+
+### Version 10.0.0
 **🏗️ Architettura Completamente Refactorizzata**
 - ✅ **Modularizzazione Completa**: Suddivisione in 9 moduli specializzati (4430+ linee totali)
 - ✅ **Debug System Avanzato**: `RBF_Debug_Logger` con logging strutturato JSON

--- a/fp-prenotazioni-ristorante-pro.php
+++ b/fp-prenotazioni-ristorante-pro.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Prenotazioni Ristorante Completo (Flatpickr, lingua dinamica)
  * Description: Prenotazioni con calendario Flatpickr IT/EN, last-minute, capienza per servizio, notifiche email (con CC), Brevo sempre e GA4/Meta (bucket standard).
- * Version:     10.0.0
+ * Version:     10.0.2
  * Author:      Francesco Passeri
  * Text Domain: rbf
  * License:     GPLv2 or later
@@ -18,7 +18,7 @@ if (!defined('ABSPATH')) {
 define('RBF_PLUGIN_FILE', __FILE__);
 define('RBF_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('RBF_PLUGIN_URL', plugin_dir_url(__FILE__));
-define('RBF_VERSION', '10.0.0');
+define('RBF_VERSION', '10.0.2');
 
 // Debug configuration (will be set during WordPress initialization)
 // These constants will be defined in rbf_load_modules() to ensure WordPress functions are available
@@ -98,7 +98,12 @@ function rbf_activate_plugin() {
     if (function_exists('rbf_register_post_type')) {
         rbf_register_post_type();
     }
-    
+
+    // Clear any cached availability to prevent stale results
+    if (function_exists('rbf_clear_availability_cache')) {
+        rbf_clear_availability_cache();
+    }
+
     // Flush rewrite rules to ensure custom post types work
     flush_rewrite_rules();
 }

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -197,7 +197,7 @@ function rbf_custom_column_data($column, $post_id) {
         case 'rbf_value':
             $people = intval(get_post_meta($post_id, 'rbf_persone', true));
             $meal = get_post_meta($post_id, 'rbf_meal', true);
-            $options = get_option('rbf_settings', rbf_get_default_settings());
+            $options = rbf_get_settings();
             $valore_pp = (float) ($options['valore_' . $meal] ?? 0);
             $valore_tot = $valore_pp * $people;
             if ($valore_tot > 0) {
@@ -244,6 +244,9 @@ function rbf_register_settings() {
         'default' => rbf_get_default_settings(),
     ]);
 }
+
+// Clear cached availability when settings change
+add_action('update_option_rbf_settings', 'rbf_clear_availability_cache', 10, 0);
 
 /**
  * Sanitize settings callback
@@ -327,7 +330,7 @@ function rbf_enqueue_admin_styles($hook) {
         $hook !== 'prenotazioni_page_rbf_export' &&
         strpos($hook,'edit.php?post_type=rbf_booking') === false) return;
 
-    wp_enqueue_style('rbf-admin-css', plugin_dir_url(dirname(__FILE__)) . 'assets/css/admin.css', [], '10.0.0.' . time());
+    wp_enqueue_style('rbf-admin-css', plugin_dir_url(dirname(__FILE__)) . 'assets/css/admin.css', [], RBF_VERSION . '.' . time());
 }
 
 /**
@@ -489,7 +492,7 @@ function rbf_settings_page_html() {
 function rbf_calendar_page_html() {
     wp_enqueue_style('fullcalendar-css', 'https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.css', [], '5.11.3');
     wp_enqueue_script('fullcalendar-js', 'https://cdn.jsdelivr.net/npm/fullcalendar@5.11.3/main.min.js', ['jquery'], '5.11.3', true);
-    wp_enqueue_script('rbf-admin-js', plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin.js', ['jquery', 'fullcalendar-js'], '10.0.0.' . time(), true);
+    wp_enqueue_script('rbf-admin-js', plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin.js', ['jquery', 'fullcalendar-js'], RBF_VERSION . '.' . time(), true);
     
     wp_localize_script('rbf-admin-js', 'rbfAdminData', [
         'ajaxUrl' => admin_url('admin-ajax.php'),
@@ -666,7 +669,7 @@ function rbf_update_booking_data_callback() {
  * Add booking page HTML
  */
 function rbf_add_booking_page_html() {
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $message = '';
 
     if (!empty($_POST) && check_admin_referer('rbf_add_backend_booking')) {
@@ -1071,7 +1074,7 @@ function rbf_get_booking_analytics($start_date, $end_date) {
         $start_date, $end_date
     ));
     
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $statuses = rbf_get_booking_statuses();
     $meals = [
         'pranzo' => rbf_translate_string('Pranzo'),
@@ -1407,7 +1410,7 @@ function rbf_export_json($bookings, $start_date, $end_date) {
             'generated' => current_time('Y-m-d H:i:s'),
             'date_range' => ['start' => $start_date, 'end' => $end_date],
             'total_bookings' => count($bookings),
-            'plugin_version' => '10.0.0'
+            'plugin_version' => RBF_VERSION
         ],
         'bookings' => []
     ];

--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -107,7 +107,7 @@ function rbf_handle_booking_submission() {
     }
 
     // Get settings for advance booking validation
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     
     // Check maximum advance booking time
     $max_advance_hours = absint($options['max_advance_hours'] ?? 72);
@@ -191,7 +191,7 @@ function rbf_handle_booking_submission() {
     }
 
     delete_transient('rbf_avail_' . $date . '_' . $slot);
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $valore_pp  = (float) ($options['valore_' . $meal] ?? 0);
     $valore_tot = $valore_pp * $people;
     $event_id   = 'rbf_' . $post_id; // usato per Pixel (browser) e CAPI (server)
@@ -360,7 +360,7 @@ function rbf_ajax_get_availability_callback() {
     }
 
     // Get settings
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     
     // Step 1: Check if restaurant is open on this day of the week
     $day_of_week = date('w', strtotime($date));

--- a/includes/debug-logger.php
+++ b/includes/debug-logger.php
@@ -205,7 +205,7 @@ class RBF_Debug_Logger {
         $logs = get_option('rbf_debug_logs', []);
         $export_data = [
             'timestamp' => current_time('mysql'),
-            'version' => get_option('rbf_version', '10.0.0'),
+            'version' => get_option('rbf_version', RBF_VERSION),
             'logs' => $logs,
             'stats' => self::get_log_stats()
         ];

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -18,8 +18,7 @@ function rbf_enqueue_frontend_assets() {
     global $post;
     if (!is_singular() || !$post || !has_shortcode($post->post_content, 'ristorante_booking_form')) return;
 
-    $plugin_version = '10.0.0';
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $locale = rbf_current_lang(); // 'it' o 'en'
 
     // Flatpickr
@@ -39,10 +38,10 @@ function rbf_enqueue_frontend_assets() {
     $deps[] = 'rbf-intl-tel-input';
 
     // Frontend styles
-    wp_enqueue_style('rbf-frontend-css', plugin_dir_url(dirname(__FILE__)) . 'assets/css/frontend.css', ['rbf-flatpickr-css'], '10.0.0.' . time());
+    wp_enqueue_style('rbf-frontend-css', plugin_dir_url(dirname(__FILE__)) . 'assets/css/frontend.css', ['rbf-flatpickr-css'], RBF_VERSION . '.' . time());
 
     // Frontend script (must be enqueued before wp_localize_script)
-    wp_enqueue_script('rbf-frontend-js', plugin_dir_url(dirname(__FILE__)) . 'assets/js/frontend.js', $deps, '10.0.0.' . time(), true);
+    wp_enqueue_script('rbf-frontend-js', plugin_dir_url(dirname(__FILE__)) . 'assets/js/frontend.js', $deps, RBF_VERSION . '.' . time(), true);
 
     // Giorni chiusi
     $closed_days_map = ['sun'=>0,'mon'=>1,'tue'=>2,'wed'=>3,'thu'=>4,'fri'=>5,'sat'=>6];
@@ -432,7 +431,7 @@ function rbf_get_remaining_capacity($date, $slot) {
     $cached = get_transient($transient_key);
     if ($cached !== false) return (int) $cached;
 
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $total = (int) ($options['capienza_'.$slot] ?? 0);
     if ($total === 0) return 0;
 
@@ -456,7 +455,7 @@ function rbf_get_remaining_capacity($date, $slot) {
  * Get closed specific dates
  */
 function rbf_get_closed_specific($options = null) {
-    if (is_null($options)) $options = get_option('rbf_settings', rbf_get_default_settings());
+    if (is_null($options)) $options = rbf_get_settings();
     $closed_dates_str = $options['closed_dates'] ?? '';
     $closed_items = array_filter(array_map('trim', explode("\n", $closed_dates_str)));
     $singles = []; $ranges = [];

--- a/includes/integrations.php
+++ b/includes/integrations.php
@@ -16,7 +16,7 @@ if (!defined('ABSPATH')) {
  */
 add_action('wp_footer','rbf_add_tracking_scripts_to_footer');
 function rbf_add_tracking_scripts_to_footer() {
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $ga4_id = $options['ga4_id'] ?? '';
     $meta_pixel_id = $options['meta_pixel_id'] ?? '';
 
@@ -133,7 +133,7 @@ function rbf_add_tracking_scripts_to_footer() {
  * Send admin notification email (to both restaurant and webmaster)
  */
 function rbf_send_admin_notification_email($first_name, $last_name, $email, $date, $time, $people, $notes, $tel, $meal) {
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $restaurant_email = $options['notification_email'];
     $webmaster_email = $options['webmaster_email'];
     
@@ -186,7 +186,7 @@ HTML;
  * Trigger Brevo automation (simplified - only Brevo, no WordPress emails)
  */
 function rbf_trigger_brevo_automation($first_name, $last_name, $email, $date, $time, $people, $notes, $lang, $tel, $marketing, $meal) {
-    $options = get_option('rbf_settings', rbf_get_default_settings());
+    $options = rbf_get_settings();
     $api_key = $options['brevo_api'] ?? '';
     $list_id = $lang === 'en' ? ($options['brevo_list_en'] ?? '') : ($options['brevo_list_it'] ?? '');
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -57,6 +57,32 @@ function rbf_current_lang() {
 }
 
 /**
+ * Retrieve plugin settings merged with defaults.
+ *
+ * Ensures new options have sensible default values even if the settings
+ * were saved before the option was introduced.
+ *
+ * @return array
+ */
+function rbf_get_settings() {
+    $saved = get_option('rbf_settings', []);
+    return wp_parse_args($saved, rbf_get_default_settings());
+}
+
+/**
+ * Clear cached availability transients.
+ */
+function rbf_clear_availability_cache() {
+    global $wpdb;
+    // Retrieve all transient names related to availability
+    $options = $wpdb->get_col("SELECT option_name FROM {$wpdb->options} WHERE option_name LIKE '_transient_rbf_avail_%'");
+    foreach ($options as $option) {
+        $key = str_replace('_transient_', '', $option);
+        delete_transient($key);
+    }
+}
+
+/**
  * Translate strings to English
  */
 function rbf_translate_string($text) {


### PR DESCRIPTION
## Summary
- ensure availability cache is cleared on plugin activation or settings update
- bump plugin version and docs to 10.0.2

## Testing
- `php -l fp-prenotazioni-ristorante-pro.php`
- `php -l includes/utils.php`
- `php -l includes/admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8d4f5654c832f839b71aed1eda491