### PR TITLE
Separate consent checkboxes and fix aperitif availability

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -682,6 +682,9 @@
 .rbf-tel-fallback {
     padding-left: 30px !important;
 }
+
+/* Style individual consent labels to stack vertically */
+.rbf-checkbox-group label {
     display: flex;
     align-items: flex-start;
     gap: 12px;

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -433,7 +433,12 @@ function rbf_get_remaining_capacity($date, $slot) {
 
     $options = rbf_get_settings();
     $total = (int) ($options['capienza_'.$slot] ?? 0);
-    if ($total === 0) return 0;
+
+    // Treat zero capacity as unlimited to avoid blocking services like aperitivo
+    if ($total === 0) {
+        set_transient($transient_key, PHP_INT_MAX, HOUR_IN_SECONDS);
+        return PHP_INT_MAX;
+    }
 
     global $wpdb;
     $spots_taken = $wpdb->get_var($wpdb->prepare(


### PR DESCRIPTION
## Summary
- Fix consent checkbox styling so each appears on its own line
- Treat zero service capacity as unlimited to allow aperitif time slots to appear

## Testing
- `php -l includes/frontend.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8de21f3d4832fb74a8c58a248aaf6