### PR TITLE
Refactor phone prefix flag button

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -185,12 +185,13 @@ jQuery(function($) {
               formatOnDisplay: true,
               autoFormat: true,
               // Enhanced flag container styling
-              dropdownContainer: document.body,
+              // Attach dropdown directly to the input wrapper to avoid page jumps
+              // when the user clicks the flag button
               customPlaceholder: function(selectedCountryPlaceholder, selectedCountryData) {
                 return rbfData.labels.phonePlaceholder || selectedCountryPlaceholder;
               }
             });
-            
+
             if (iti) {
               console.log('Enhanced intlTelInput initialized successfully');
               
@@ -242,7 +243,22 @@ jQuery(function($) {
               
               // Add custom CSS class for styling
               el.telInput.closest('.iti').addClass('rbf-iti-enhanced');
-              
+
+              // Rebuild flag selector button to prevent anchor jumps and improve accessibility
+              const flagButton = el.telInput.closest('.iti').find('.iti__selected-flag');
+              if (flagButton.length) {
+                flagButton
+                  .attr({
+                    role: 'button',
+                    title: rbfData.labels.selectPrefix || 'Seleziona prefisso',
+                    'aria-label': rbfData.labels.selectPrefix || 'Seleziona prefisso'
+                  })
+                  .on('click', function(e) {
+                    // Prevent the default anchor behavior which caused page jump
+                    e.preventDefault();
+                  });
+              }
+
             } else {
               console.error('Failed to initialize intlTelInput - returned null');
               el.telInput.addClass('rbf-tel-fallback');

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -65,6 +65,7 @@ function rbf_enqueue_frontend_assets() {
             'noTime' => rbf_translate_string('Nessun orario disponibile'),
             'invalidPhone' => rbf_translate_string('Il numero di telefono inserito non è valido.'),
             'phonePlaceholder' => rbf_translate_string('Inserisci il numero di telefono'),
+            'selectPrefix' => rbf_translate_string('Seleziona prefisso internazionale'),
             'sundayBrunchNotice' => rbf_translate_string('Di Domenica il servizio è Brunch con menù alla carta.'),
             'privacyRequired' => rbf_translate_string('Devi accettare la Privacy Policy per procedere.'),
         ],


### PR DESCRIPTION
## Summary
- prevent flag prefix dropdown from jumping the page by attaching it to the input wrapper
- rebuild flag selector button with accessible attributes and default-prevented click
- expose `selectPrefix` label for translations

## Testing
- `php -l includes/frontend.php`
- `node --check assets/js/frontend.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8e0da10ec832fa3ee22c438bcb1c7