### PR TITLE
Widen phone prefix selector and default to Italy

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -334,7 +334,7 @@
     top: 0;
     bottom: 0;
     left: 0;
-    width: 65px;
+    width: 90px;
     background: linear-gradient(135deg, #f8f9fa 0%, #ffffff 100%);
     border-right: 1px solid var(--rbf-border);
     border-radius: var(--rbf-radius) 0 0 var(--rbf-radius);
@@ -505,7 +505,7 @@
 
 /* Enhanced Input Field Integration */
 .iti input[type="tel"] {
-    padding-left: 75px !important;
+    padding-left: 100px !important;
     border-radius: 0 var(--rbf-radius) var(--rbf-radius) 0 !important;
     border: none !important;
     width: 100% !important;
@@ -535,7 +535,7 @@
 }
 
 .iti--allow-dropdown input {
-    padding-left: 75px !important;
+    padding-left: 100px !important;
     border-radius: 0 var(--rbf-radius) var(--rbf-radius) 0 !important;
 }
 
@@ -569,20 +569,20 @@
     
     .iti__selected-flag {
         min-height: 56px;
-        width: 70px;
+        width: 95px;
         display: flex;
         align-items: center;
         justify-content: center;
         border-radius: var(--rbf-radius) 0 0 var(--rbf-radius);
     }
-    
+
     .iti__flag-container {
-        width: 70px;
+        width: 95px;
         border-radius: var(--rbf-radius) 0 0 var(--rbf-radius);
     }
-    
+
     .iti input[type="tel"] {
-        padding-left: 80px !important;
+        padding-left: 105px !important;
         font-size: 16px !important; /* Prevent iOS zoom */
         min-height: 54px;
         border-radius: 0 var(--rbf-radius) var(--rbf-radius) 0 !important;

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -373,7 +373,7 @@ function rbf_render_booking_form() {
                 <input type="hidden" name="rbf_referrer" id="rbf_referrer" value="">
 
                 <input type="hidden" name="rbf_lang" value="<?php echo esc_attr(rbf_current_lang()); ?>">
-                <input type="hidden" name="rbf_country_code" id="rbf_country_code" value="">
+                <input type="hidden" name="rbf_country_code" id="rbf_country_code" value="it">
                 <button id="rbf-submit" type="submit" disabled style="display:none;"><?php echo esc_html(rbf_translate_string('Prenota')); ?></button>
             </form>
         <?php endif; ?>


### PR DESCRIPTION
## Summary
- enlarge telephone prefix flag container and adjust padding for clearer dialing code display
- set hidden country code field to default to Italy

## Testing
- `php -l includes/frontend.php`
- `node --check assets/js/frontend.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e73f4888832f9844bff2aa2c7f1f