### PR TITLE
Use admin email as default notification address

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -20,7 +20,7 @@ function rbf_get_default_settings() {
         'ga4_api_secret' => '',
         'meta_pixel_id' => '',
         'meta_access_token' => '',
-        'notification_email' => 'info@villadianella.it',
+        'notification_email' => get_option('admin_email'),
         'webmaster_email' => '',
         'brevo_api' => '',
         'brevo_list_it' => '',


### PR DESCRIPTION
## Summary
- use the site's configured administrator email as the default notification address

## Testing
- `php tests/buffer-overbooking-tests.php`
- `php tests/edge-case-tests.php`
- `php tests/integration-test.php`
- `php tests/table-management-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdccbc5570832f8d121164060675ba