### PR TITLE
Use translation helper for availability errors

### DIFF
--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -345,13 +345,13 @@ add_action('wp_ajax_nopriv_rbf_get_availability', 'rbf_ajax_get_availability_cal
 function rbf_ajax_get_availability_callback() {
     // Verify nonce for security
     if (!check_ajax_referer('rbf_ajax_nonce', 'nonce', false)) {
-        wp_send_json_error(['message' => 'Security check failed']);
+        wp_send_json_error(['message' => rbf_translate_string('Controllo di sicurezza fallito.')]);
         return;
     }
 
     // Validate required parameters
     if (empty($_POST['date']) || empty($_POST['meal'])) {
-        rbf_handle_error('Missing required parameters', 'ajax_validation');
+        rbf_handle_error(rbf_translate_string('Parametri obbligatori mancanti.'), 'ajax_validation');
         return;
     }
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -352,6 +352,8 @@ function rbf_translate_string($text) {
         'Grazie! La tua prenotazione è stata inviata con successo.' => 'Thank you! Your booking has been sent successfully.',
         'Tutti i campi sono obbligatori.' => 'All fields are required.',
         'Errore di sicurezza.' => 'Security error.',
+        'Controllo di sicurezza fallito.' => 'Security check failed.',
+        'Parametri obbligatori mancanti.' => 'Missing required parameters.',
         'Data non valida.' => 'Invalid date.',
         'Indirizzo email non valido.' => 'Invalid email address.',
         'Orario non valido.' => 'Invalid time.',


### PR DESCRIPTION
## Summary
- Replace literal error strings in AJAX availability handler with `rbf_translate_string`
- Add English translations for new messages in `rbf_translate_string` map

## Testing
- `php tests/buffer-overbooking-tests.php`
- `php tests/edge-case-tests.php`
- `php tests/integration-test.php`
- `php tests/table-management-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdcdd3d614832f9f1040f8a641c1d7