### PR TITLE
Refine asset versioning

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -665,10 +665,13 @@ function rbf_handle_success($message, $data = [], $redirect_url = null) {
 
 /**
  * Centralized asset version helper for cache-busting
- * Consolidates the RBF_VERSION . '.' . time() pattern used across files
+ * Returns base version with optional timestamp when debugging
  */
 function rbf_get_asset_version() {
-    return RBF_VERSION . '.' . time();
+    if (defined('SCRIPT_DEBUG') && SCRIPT_DEBUG) {
+        return RBF_VERSION . '.' . time();
+    }
+    return RBF_VERSION;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Avoid unnecessary cache busting in production by removing timestamp from asset version
- Only append timestamp when `SCRIPT_DEBUG` is enabled
- Confirm frontend and admin asset enqueues still use `rbf_get_asset_version`

## Testing
- `php tests/buffer-overbooking-tests.php`
- `php tests/edge-case-tests.php`
- `php tests/integration-test.php`
- `php tests/table-management-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd23d1510832f8140a87a2e72dbd9