### PR TITLE
Refine transient cleanup patterns

### DIFF
--- a/fp-prenotazioni-ristorante-pro.php
+++ b/fp-prenotazioni-ristorante-pro.php
@@ -32,16 +32,16 @@ function rbf_clear_transients() {
 
     // Clear RBF-specific transients with improved pattern matching
     $transient_patterns = [
-        '_transient_rbf_%',
-        '_transient_timeout_rbf_%'
+        '_transient_rbf_',
+        '_transient_timeout_rbf_'
     ];
-    
+
     foreach ($transient_patterns as $pattern) {
-        $escaped_pattern = $wpdb->esc_like($pattern);
+        $pattern_like = $wpdb->esc_like($pattern) . '%';
         $deleted = $wpdb->query(
             $wpdb->prepare(
                 "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-                $escaped_pattern
+                $pattern_like
             )
         );
         


### PR DESCRIPTION
## Summary
- simplify transient pattern array for cleanup
- use explicit esc_like + wildcard for transient cleanup queries

## Testing
- `for file in tests/*.php; do echo "Running $file"; php $file; echo "---"; done`


------
https://chatgpt.com/codex/tasks/task_e_68bdd2cfdf9c832fae2c107abe55ed07