### PR TITLE
Use WordPress timezone for customer booking comparison

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -291,8 +291,9 @@ function rbf_render_customer_booking_management() {
         
         <?php
         // Show appropriate actions based on status and date
-        $booking_date = DateTime::createFromFormat('Y-m-d', $date);
-        $today = new DateTime();
+        $tz = rbf_wp_timezone();
+        $booking_date = DateTime::createFromFormat('Y-m-d', $date, $tz);
+        $today = new DateTime('now', $tz);
         $can_cancel = in_array($status, ['confirmed']) && $booking_date > $today;
         
         if ($can_cancel) : ?>


### PR DESCRIPTION
## Summary
- ensure customer booking management uses WordPress timezone
- create and compare booking date and current date in consistent timezone

## Testing
- `php -l includes/frontend.php`
- `php tests/buffer-overbooking-tests.php`
- `php tests/edge-case-tests.php`
- `php tests/integration-test.php`
- `php tests/table-management-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd3532a60832f918ba000ec1a15c4