### PR TITLE
Sanitize action in table management

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1975,8 +1975,10 @@ function rbf_tables_page_html() {
         }
         
         global $wpdb;
-        
-        switch ($_POST['action']) {
+
+        $action = sanitize_text_field($_POST['action']);
+
+        switch ($action) {
             case 'add_area':
                 $name = sanitize_text_field($_POST['area_name']);
                 $description = sanitize_textarea_field($_POST['area_description']);
@@ -2052,6 +2054,9 @@ function rbf_tables_page_html() {
                         echo '<div class="notice notice-error"><p>Errore nell\'aggiunta del gruppo.</p></div>';
                     }
                 }
+                break;
+            default:
+                echo '<div class="notice notice-error"><p>' . esc_html(rbf_translate_string('Azione non valida.')) . '</p></div>';
                 break;
         }
     }


### PR DESCRIPTION
## Summary
- Sanitize incoming table-management action and use it in switch
- Add default branch with translated error for unsupported actions

## Testing
- `php tests/table-management-tests.php`
- `php tests/buffer-overbooking-tests.php`
- `php tests/edge-case-tests.php`
- `php tests/integration-test.php`


------
https://chatgpt.com/codex/tasks/task_e_68bdd5420f1c832fa0127151bc2d848e