### PR TITLE
refactor: centralize restaurant open checks

### DIFF
--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -107,31 +107,10 @@ function rbf_handle_booking_submission() {
         return;
     }
 
-    // Validate that the date is not in the closed dates list
-    $options = rbf_get_settings();
-    
-    // Check if restaurant is open on this day of the week
-    $day_of_week = date('w', strtotime($date));
-    $day_keys = ['sun','mon','tue','wed','thu','fri','sat'];
-    $day_key = $day_keys[$day_of_week];
-
-    if (($options["open_{$day_key}"] ?? 'no') !== 'yes') {
-        rbf_handle_error(rbf_translate_string('Il ristorante è chiuso in questo giorno della settimana.'), 'closed_day_validation', $redirect_url . $anchor);
+    // Validate that the restaurant is open for the selected date
+    if (!rbf_is_restaurant_open($date, $meal)) {
+        rbf_handle_error(rbf_translate_string('Il ristorante è chiuso nella data selezionata.'), 'restaurant_closed', $redirect_url . $anchor);
         return;
-    }
-
-    // Check specific closed dates
-    $closed_specific = rbf_get_closed_specific($options);
-    if (in_array($date, $closed_specific['singles'], true)) {
-        rbf_handle_error(rbf_translate_string('Il ristorante è chiuso nella data selezionata.'), 'closed_date_validation', $redirect_url . $anchor);
-        return;
-    }
-    
-    foreach ($closed_specific['ranges'] as $range) {
-        if ($date >= $range['from'] && $date <= $range['to']) {
-            rbf_handle_error(rbf_translate_string('Il ristorante è chiuso nella data selezionata.'), 'closed_date_range_validation', $redirect_url . $anchor);
-            return;
-        }
     }
     
     // Validate time data format
@@ -469,32 +448,14 @@ function rbf_ajax_get_availability_callback() {
 
     // Get settings
     $options = rbf_get_settings();
-    
-    // Step 1: Check if restaurant is open on this day of the week
-    $day_of_week = date('w', strtotime($date));
-    $day_keys = ['sun','mon','tue','wed','thu','fri','sat'];
-    $day_key = $day_keys[$day_of_week];
 
-    if (($options["open_{$day_key}"] ?? 'no') !== 'yes') {
+    // Ensure restaurant is open for requested date
+    if (!rbf_is_restaurant_open($date, $meal)) {
         wp_send_json_success([]);
         return;
     }
 
-    // Step 2: Check specific closed dates
-    $closed_specific = rbf_get_closed_specific($options);
-    if (in_array($date, $closed_specific['singles'], true)) {
-        wp_send_json_success([]);
-        return;
-    }
-    
-    foreach ($closed_specific['ranges'] as $range) {
-        if ($date >= $range['from'] && $date <= $range['to']) {
-            wp_send_json_success([]);
-            return;
-        }
-    }
-
-    // Step 3: Get configured time slots for this meal, considering special exceptions
+    // Step 2: Get configured time slots for this meal, considering special exceptions
     $special_hours = rbf_get_special_hours_for_date($date, $meal, $options);
     $times = [];
     

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -164,6 +164,42 @@ function rbf_get_valid_meal_ids() {
 }
 
 /**
+ * Determine if restaurant is open for a given date and meal.
+ * Encapsulates weekday and closed-date/range checks.
+ *
+ * @param string $date Date in Y-m-d format
+ * @param string $meal Meal identifier (currently unused but reserved for future logic)
+ * @return bool True if restaurant is open, false if closed
+ */
+function rbf_is_restaurant_open($date, $meal) {
+    $options = rbf_get_settings();
+
+    // Check day of week availability
+    $day_of_week = date('w', strtotime($date));
+    $day_keys = ['sun','mon','tue','wed','thu','fri','sat'];
+    $day_key = $day_keys[$day_of_week];
+
+    if (($options["open_{$day_key}"] ?? 'no') !== 'yes') {
+        return false;
+    }
+
+    // Check specific closed dates and ranges
+    $closed_specific = rbf_get_closed_specific($options);
+
+    if (in_array($date, $closed_specific['singles'], true)) {
+        return false;
+    }
+
+    foreach ($closed_specific['ranges'] as $range) {
+        if ($date >= $range['from'] && $date <= $range['to']) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
  * WordPress timezone compatibility function
  */
 if (!function_exists('rbf_wp_timezone')) {

--- a/tests/restaurant-open-tests.php
+++ b/tests/restaurant-open-tests.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * Tests for rbf_is_restaurant_open utility function.
+ * Provides manual verification for weekday and closed date logic.
+ */
+
+// Define ABSPATH to satisfy direct access checks
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+require_once __DIR__ . '/../includes/utils.php';
+
+// --- WordPress function stubs for test environment ---
+if (!function_exists('get_option')) {
+    function get_option($name, $default = []) {
+        if ($name === 'rbf_settings') {
+            return [
+                'open_mon' => 'yes',
+                'open_tue' => 'no',
+                'open_wed' => 'yes',
+                'open_thu' => 'yes',
+                'open_fri' => 'yes',
+                'open_sat' => 'yes',
+                'open_sun' => 'yes',
+                'closed_dates' => "2024-12-25\n2024-08-15 - 2024-08-20",
+                'notification_email' => 'admin@example.com'
+            ];
+        }
+        if ($name === 'admin_email') {
+            return 'admin@example.com';
+        }
+        if ($name === 'timezone_string') {
+            return 'UTC';
+        }
+        if ($name === 'gmt_offset') {
+            return 0;
+        }
+        return $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($name, $value) {
+        // no-op for tests
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = []) {
+        return array_merge($defaults, $args);
+    }
+}
+
+// Minimal version of rbf_get_closed_specific to support tests
+if (!function_exists('rbf_get_closed_specific')) {
+    function rbf_get_closed_specific($options = null) {
+        $closed_dates_str = $options['closed_dates'] ?? '';
+        $closed_items = array_filter(array_map('trim', explode("\n", $closed_dates_str)));
+        $singles = [];
+        $ranges = [];
+        foreach ($closed_items as $item) {
+            if (strpos($item, ' - ') !== false) {
+                list($start, $end) = array_map('trim', explode(' - ', $item, 2));
+                $ranges[] = ['from' => $start, 'to' => $end];
+            } else {
+                $singles[] = $item;
+            }
+        }
+        return ['singles' => $singles, 'ranges' => $ranges, 'exceptions' => []];
+    }
+}
+
+// --- Test cases ---
+echo "Restaurant Open Function Tests\n";
+echo "================================\n";
+
+$tests = [
+    ['2024-12-23', 'pranzo', true,  'Monday open'],
+    ['2024-12-24', 'pranzo', false, 'Tuesday closed via weekday setting'],
+    ['2024-12-25', 'pranzo', false, 'Specific closed date'],
+    ['2024-08-17', 'pranzo', false, 'Within closed date range']
+];
+
+foreach ($tests as $case) {
+    list($date, $meal, $expected, $label) = $case;
+    $result = rbf_is_restaurant_open($date, $meal);
+    $status = ($result === $expected) ? '✅' : '❌';
+    echo sprintf("%s %s => %s\n", $status, $label, $result ? 'open' : 'closed');
+}
+
+echo "\n";


### PR DESCRIPTION
## Summary
- add `rbf_is_restaurant_open()` utility to encapsulate weekday and closed date logic
- use new helper in booking handler and AJAX availability endpoint
- add manual tests for restaurant open checks

## Testing
- `php tests/restaurant-open-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c72539b7ec832f9cffa6930d7654f2