### PR TITLE
Add conditional logging helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,14 @@ Usa gli strumenti integrati di debug:
 3. **GA4 DebugView**: Verifica eventi in tempo reale
 4. **Facebook Events Manager**: Controlla duplicazione Pixel/CAPI
 
+### Logging di Debug
+
+Utilizza la funzione `rbf_log($message)` per registrare messaggi diagnostici.
+La funzione invia il messaggio a `error_log` solo quando `WP_DEBUG` è attivo oppure
+quando il flag `RBF_FORCE_LOG` è definito e impostato a `true` (ad es. nel `wp-config.php`).
+In questo modo i log possono essere abilitati anche in produzione senza modificare
+la configurazione globale di WordPress.
+
 ## 📋 Changelog
 
 ### Version 1.5

--- a/docs/email-failover-system.md
+++ b/docs/email-failover-system.md
@@ -177,7 +177,7 @@ echo "Fallback Rate: " . $health['fallback_rate'] . "%";
    ```php
    $test_email = wp_mail('test@example.com', 'Test', 'Test message');
    if (!$test_email) {
-       error_log('wp_mail failed: ' . print_r(error_get_last(), true));
+       rbf_log('wp_mail failed: ' . print_r(error_get_last(), true));
    }
    ```
 

--- a/fp-prenotazioni-ristorante-pro.php
+++ b/fp-prenotazioni-ristorante-pro.php
@@ -20,6 +20,9 @@ define('RBF_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('RBF_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('RBF_VERSION', '1.5');
 
+// Load utilities early for logging support
+require_once RBF_PLUGIN_DIR . 'includes/utils.php';
+
 /**
  * Clear all transients used by the plugin.
  */
@@ -45,9 +48,9 @@ function rbf_clear_transients() {
             )
         );
         
-        // Log cleanup for debugging if WP_DEBUG is enabled
-        if (WP_DEBUG && $deleted > 0) {
-            error_log("RBF Plugin: Cleared {$deleted} transients matching pattern: {$pattern}");
+        // Log cleanup for debugging
+        if ($deleted > 0) {
+            rbf_log("RBF Plugin: Cleared {$deleted} transients matching pattern: {$pattern}");
         }
     }
 
@@ -59,8 +62,8 @@ function rbf_clear_transients() {
         )
     );
     
-    if (WP_DEBUG && $deleted_avail > 0) {
-        error_log("RBF Plugin: Cleared {$deleted_avail} availability transients");
+    if ($deleted_avail > 0) {
+        rbf_log("RBF Plugin: Cleared {$deleted_avail} availability transients");
     }
 
     if (function_exists('wp_cache_flush')) {

--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -27,7 +27,7 @@ function rbf_validate_request($post, $redirect_url, $anchor) {
     // Anti-bot validation
     $bot_detected = rbf_detect_bot_submission($post);
     if ($bot_detected['is_bot']) {
-        error_log("RBF Bot Detection: " . $bot_detected['reason'] . " - IP: " . $_SERVER['REMOTE_ADDR']);
+        rbf_log("RBF Bot Detection: " . $bot_detected['reason'] . " - IP: " . $_SERVER['REMOTE_ADDR']);
 
         if ($bot_detected['severity'] === 'high') {
             $options = rbf_get_settings();
@@ -36,11 +36,11 @@ function rbf_validate_request($post, $redirect_url, $anchor) {
             if ($recaptcha_configured && !empty($post['g-recaptcha-response'])) {
                 $recaptcha_result = rbf_verify_recaptcha($post['g-recaptcha-response']);
                 if (!$recaptcha_result['success']) {
-                    error_log("RBF reCAPTCHA Failed: " . $recaptcha_result['reason'] . " - IP: " . $_SERVER['REMOTE_ADDR']);
+                    rbf_log("RBF reCAPTCHA Failed: " . $recaptcha_result['reason'] . " - IP: " . $_SERVER['REMOTE_ADDR']);
                     rbf_handle_error(rbf_translate_string('Verifica di sicurezza fallita. Per favore riprova.'), 'recaptcha_failed', $redirect_url . $anchor);
                     return false;
                 }
-                error_log("RBF Bot detected but reCAPTCHA passed - allowing submission");
+                rbf_log("RBF Bot detected but reCAPTCHA passed - allowing submission");
             } else {
                 rbf_handle_error(rbf_translate_string('Rilevata attività sospetta. Per favore riprova.'), 'bot_detected', $redirect_url . $anchor);
                 return false;

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -11,6 +11,18 @@ if (!defined('ABSPATH')) {
 }
 
 /**
+ * Conditional debug logger for the plugin.
+ * Logs messages only when WP_DEBUG or RBF_FORCE_LOG is enabled.
+ *
+ * @param string $message Message to log.
+ */
+function rbf_log($message) {
+    if ((defined('WP_DEBUG') && WP_DEBUG) || (defined('RBF_FORCE_LOG') && RBF_FORCE_LOG)) {
+        error_log($message);
+    }
+}
+
+/**
  * Get default plugin settings
  */
 function rbf_get_default_settings() {
@@ -223,9 +235,7 @@ if (!function_exists('rbf_wp_timezone')) {
             return new DateTimeZone(sprintf('%s%02d:%02d', $sign, abs($hours), $minutes));
         } catch (Exception $e) {
             // Log the error if debugging is enabled
-            if (WP_DEBUG) {
-                error_log('RBF Plugin: Timezone creation failed: ' . $e->getMessage());
-            }
+            rbf_log('RBF Plugin: Timezone creation failed: ' . $e->getMessage());
             // Fallback to UTC on any error
             return new DateTimeZone('UTC');
         }
@@ -758,10 +768,8 @@ function rbf_validate_date($date) {
  */
 function rbf_handle_error($message, $context = 'general', $redirect_url = null) {
     // Log error for debugging
-    if (WP_DEBUG) {
-        error_log("RBF Error [{$context}]: {$message}");
-    }
-    
+    rbf_log("RBF Error [{$context}]: {$message}");
+
     // Fire action for error tracking
     do_action('rbf_error_logged', $message, $context);
     
@@ -1314,7 +1322,7 @@ function rbf_load_brand_json() {
     
     $config = json_decode($json_content, true);
     if (json_last_error() !== JSON_ERROR_NONE) {
-        error_log('FPPR Brand Config: Invalid JSON in ' . $json_file);
+        rbf_log('FPPR Brand Config: Invalid JSON in ' . $json_file);
         return false;
     }
     
@@ -1816,7 +1824,7 @@ function rbf_verify_recaptcha($token, $action = 'booking_submit') {
     ]);
     
     if (is_wp_error($response)) {
-        error_log('reCAPTCHA verification failed: ' . $response->get_error_message());
+        rbf_log('reCAPTCHA verification failed: ' . $response->get_error_message());
         return [
             'success' => true, // Allow on API failure to avoid blocking legitimate users
             'score' => 0.5,


### PR DESCRIPTION
## Summary
- add rbf_log utility for conditional debug logging
- replace direct error_log calls across plugin with rbf_log
- document logging usage in README and email failover docs

## Testing
- `php -l includes/utils.php`
- `php -l includes/booking-handler.php`
- `php -l fp-prenotazioni-ristorante-pro.php`


------
https://chatgpt.com/codex/tasks/task_e_68c77bf71a24832fad9dddf2f2c6991f