### PR TITLE
Fix booking metadata keys and update references

### DIFF
--- a/includes/ai-suggestions.php
+++ b/includes/ai-suggestions.php
@@ -331,7 +331,7 @@ function rbf_check_time_slot_capacity($date, $meal, $time, $people) {
          FROM {$wpdb->posts} p
          INNER JOIN {$wpdb->postmeta} pm_people ON p.ID = pm_people.post_id AND pm_people.meta_key = 'rbf_persone'
          INNER JOIN {$wpdb->postmeta} pm_date ON p.ID = pm_date.post_id AND pm_date.meta_key = 'rbf_data'
-         INNER JOIN {$wpdb->postmeta} pm_meal ON p.ID = pm_meal.post_id AND pm_meal.meta_key = 'rbf_orario'
+         INNER JOIN {$wpdb->postmeta} pm_meal ON p.ID = pm_meal.post_id AND pm_meal.meta_key = 'rbf_meal'
          WHERE p.post_type = 'rbf_booking' AND p.post_status = 'publish'
          AND pm_date.meta_value = %s AND pm_meal.meta_value = %s",
         $date, $meal

--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -280,8 +280,8 @@ function rbf_create_booking_post($data, $redirect_url, $anchor) {
         'post_status' => 'publish',
         'meta_input'  => [
             'rbf_data'          => $date,
-            'rbf_meal'          => $slot,
-            'rbf_orario'        => $slot,
+            'rbf_meal'          => $meal,
+            'rbf_orario'        => $time,
             'rbf_time'          => $time,
             'rbf_persone'       => $people,
             'rbf_nome'          => $first_name,

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -292,7 +292,7 @@ function rbf_render_customer_booking_management() {
     $date = get_post_meta($booking_id, 'rbf_data', true);
     $time = get_post_meta($booking_id, 'rbf_time', true);
     $people = get_post_meta($booking_id, 'rbf_persone', true);
-    $meal = get_post_meta($booking_id, 'rbf_orario', true);
+    $meal = get_post_meta($booking_id, 'rbf_meal', true) ?: get_post_meta($booking_id, 'rbf_orario', true);
     $notes = get_post_meta($booking_id, 'rbf_allergie', true);
     $status = get_post_meta($booking_id, 'rbf_booking_status', true) ?: 'pending';
     $created = get_post_meta($booking_id, 'rbf_booking_created', true);
@@ -818,7 +818,7 @@ function rbf_get_remaining_capacity($date, $slot) {
          FROM {$wpdb->posts} p
          INNER JOIN {$wpdb->postmeta} pm_people ON p.ID = pm_people.post_id AND pm_people.meta_key = 'rbf_persone'
          INNER JOIN {$wpdb->postmeta} pm_date ON p.ID = pm_date.post_id AND pm_date.meta_key = 'rbf_data'
-         INNER JOIN {$wpdb->postmeta} pm_slot ON p.ID = pm_slot.post_id AND pm_slot.meta_key = 'rbf_orario'
+         INNER JOIN {$wpdb->postmeta} pm_slot ON p.ID = pm_slot.post_id AND pm_slot.meta_key = 'rbf_meal'
          WHERE p.post_type = 'rbf_booking' AND p.post_status = 'publish'
          AND pm_date.meta_value = %s AND pm_slot.meta_value = %s",
         $date, $slot

--- a/includes/integrations.php
+++ b/includes/integrations.php
@@ -133,7 +133,7 @@ function rbf_add_booking_tracking_script() {
             // Get all meta in single call for performance
             $meta = get_post_meta($booking_id);
             $value = $meta['rbf_valore_tot'][0] ?? 0;
-            $meal = $meta['rbf_orario'][0] ?? 'pranzo';
+            $meal = $meta['rbf_meal'][0] ?? ($meta['rbf_orario'][0] ?? 'pranzo');
             $people = $meta['rbf_persone'][0] ?? 1;
             $bucket = $meta['rbf_source_bucket'][0] ?? 'organic';
             $gclid = $meta['rbf_gclid'][0] ?? '';

--- a/includes/optimistic-locking.php
+++ b/includes/optimistic-locking.php
@@ -111,7 +111,7 @@ function rbf_calculate_current_bookings($date, $slot_id) {
          FROM {$wpdb->posts} p
          INNER JOIN {$wpdb->postmeta} pm_people ON p.ID = pm_people.post_id AND pm_people.meta_key = 'rbf_persone'
          INNER JOIN {$wpdb->postmeta} pm_date ON p.ID = pm_date.post_id AND pm_date.meta_key = 'rbf_data'
-         INNER JOIN {$wpdb->postmeta} pm_slot ON p.ID = pm_slot.post_id AND pm_slot.meta_key = 'rbf_orario'
+         INNER JOIN {$wpdb->postmeta} pm_slot ON p.ID = pm_slot.post_id AND pm_slot.meta_key = 'rbf_meal'
          WHERE p.post_type = 'rbf_booking' AND p.post_status = 'publish'
          AND pm_date.meta_value = %s AND pm_slot.meta_value = %s",
         $date, $slot_id


### PR DESCRIPTION
## Summary
- Ensure booking posts store meal and time under correct meta keys
- Update admin, utilities, integrations, and queries to use rbf_meal for meal and rbf_orario for time
- Maintain backward compatibility with legacy rbf_orario data

## Testing
- `php -l includes/booking-handler.php`
- `php -l includes/optimistic-locking.php`
- `php -l includes/admin.php`
- `php -l includes/frontend.php`
- `php -l includes/utils.php`
- `php -l includes/integrations.php`
- `php -l includes/ai-suggestions.php`
- `php tests/integration-test.php`
- `php tests/inline-validation-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c77f106d80832fa6638ee8cbc32da4