### PR TITLE
Implement recursive sanitization for GA4 event params

### DIFF
--- a/includes/ga4-funnel-tracking.php
+++ b/includes/ga4-funnel-tracking.php
@@ -164,8 +164,8 @@ function rbf_ajax_track_ga4_event() {
         return;
     }
     
-    // Sanitize event parameters
-    $sanitized_params = array_map('sanitize_text_field', $event_params);
+    // Sanitize event parameters recursively preserving numeric types
+    $sanitized_params = rbf_recursive_sanitize($event_params);
     
     // Send to GA4 Measurement Protocol if API secret is configured
     $config = rbf_get_ga4_config();

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -987,6 +987,36 @@ function rbf_get_utm_analytics($days = 30) {
 }
 
 /**
+ * Recursively sanitize data structures using sanitize_text_field for strings.
+ * Numeric values are preserved as proper int or float types.
+ *
+ * @param mixed $data Data to sanitize.
+ * @return mixed Sanitized data with preserved numeric types.
+ */
+function rbf_recursive_sanitize($data) {
+    if (is_array($data)) {
+        foreach ($data as $key => $value) {
+            $data[$key] = rbf_recursive_sanitize($value);
+        }
+        return $data;
+    }
+
+    if (is_string($data)) {
+        $sanitized = sanitize_text_field($data);
+        if (is_numeric($sanitized)) {
+            return strpos($sanitized, '.') !== false ? (float) $sanitized : (int) $sanitized;
+        }
+        return $sanitized;
+    }
+
+    if (is_numeric($data)) {
+        return $data + 0; // Cast to int or float as needed
+    }
+
+    return $data;
+}
+
+/**
  * Enhanced centralized input sanitization helper with security improvements
  * Reduces repetitive sanitize_text_field calls across the codebase and prevents injection attacks
  */


### PR DESCRIPTION
## Summary
- add `rbf_recursive_sanitize` to sanitize nested arrays while preserving numeric types
- apply recursive sanitizer in GA4 funnel tracking AJAX handler

## Testing
- `php -l includes/utils.php`
- `php -l includes/ga4-funnel-tracking.php`
- `php /tmp/test_sanitize.php`


------
https://chatgpt.com/codex/tasks/task_e_68c7875d556c832f8526bcec65421143