### PR TITLE
Fix flatpickr calendar positioning

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1825,7 +1825,7 @@
 .flatpickr-calendar {
     pointer-events: auto !important;
     z-index: 1100 !important;
-    position: relative !important;
+    position: absolute !important;
 }
 
 /* Ensure calendar NEVER gets disabled by loading states */


### PR DESCRIPTION
## Summary
- ensure flatpickr calendar uses absolute positioning so it renders next to the date field

## Testing
- `./validate-fix.sh`
- `node <<'NODE'
const {chromium} = require('playwright');
(async () => {
  const browser = await chromium.launch();
  const page = await browser.newPage();
  page.on('console', msg => console.log('console', msg.type(), msg.text()));
  page.on('pageerror', err => console.log('pageerror', err));
  page.on('requestfailed', req => console.log('requestfailed', req.url(), req.failure().errorText));
  await page.goto('file://' + process.cwd() + '/calendar-fix-test.html');
  await page.click('#rbf-date');
  try {
    await page.waitForSelector('.flatpickr-calendar', {timeout: 5000});
    const calBox = await page.locator('.flatpickr-calendar').boundingBox();
    const inputBox = await page.locator('#rbf-date').boundingBox();
    console.log('input', inputBox);
    console.log('calendar', calBox);
  } catch (e) {
    console.log('error', e);
  }
  await browser.close();
})();
NODE` *(fails: `net::ERR_TUNNEL_CONNECTION_FAILED`)*

------
https://chatgpt.com/codex/tasks/task_e_68c815dc9380832fba76e282965821f6