### PR TITLE
Ensure flatpickr handles missing meal availability correctly

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -640,7 +640,11 @@ jQuery(function($) {
         const dateStr = formatLocalISO(date);
         
         // Check if this meal is available on this day
-        if (rbfData.mealAvailability && rbfData.mealAvailability[selectedMeal]) {
+        if (
+          rbfData.mealAvailability &&
+          Array.isArray(rbfData.mealAvailability[selectedMeal]) &&
+          rbfData.mealAvailability[selectedMeal].length > 0
+        ) {
           const availableDays = rbfData.mealAvailability[selectedMeal];
           if (!availableDays.includes(dayKey)) {
             return true; // Disable this day for this meal


### PR DESCRIPTION
## Summary
- guard flatpickr meal availability check to only run when availability array exists and has entries

## Testing
- `node --check assets/js/frontend.js && echo 'syntax ok'`
- `php tests/restaurant-open-tests.php`


------
https://chatgpt.com/codex/tasks/task_e_68c8170e46b8832fabd9314d98369ca9