### PR TITLE
Exclude flatpickr calendar from focus restoration

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -2163,7 +2163,7 @@ jQuery(function($) {
 
     // Restore focus when closing dropdowns
     $(document).on('click', function(e) {
-      if (!$(e.target).closest('.iti').length && lastFocusedElement) {
+      if (!$(e.target).closest('.iti, .flatpickr-calendar').length && lastFocusedElement) {
         // Country dropdown closed
         if ($('.iti__country-list:visible').length === 0) {
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- Avoid closing or refocusing when clicking inside Flatpickr calendar by excluding `.flatpickr-calendar` in global click handler.

## Testing
- `./validate-fix.sh`
- `php tests/integration-test.php`
- `node <inline puppeteer script>`

------
https://chatgpt.com/codex/tasks/task_e_68c81817ef58832fb91790a3c30041e2