### PR TITLE
Normalize open day options and compute closed days accurately

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -71,9 +71,11 @@ function rbf_enqueue_frontend_assets() {
     // Giorni chiusi
     $closed_days_map = ['sun'=>0,'mon'=>1,'tue'=>2,'wed'=>3,'thu'=>4,'fri'=>5,'sat'=>6];
     $closed_days = [];
+    $open_values = ['yes', '1', 'true', 'on'];
     foreach ($closed_days_map as $key => $day_index) {
-        $is_open = $options["open_{$key}"] ?? 'yes';
-        if ($is_open === 'no') {
+        $is_open_raw = $options["open_{$key}"] ?? 'yes';
+        $is_open = in_array(strtolower((string)$is_open_raw), $open_values, true);
+        if (!$is_open) {
             $closed_days[] = $day_index;
         }
     }


### PR DESCRIPTION
## Summary
- allow `open_*` options to accept variants like `1`, `true`, and `on`
- ensure `$closed_days` collects only days that are not explicitly open

## Testing
- `php -l includes/frontend.php`
- `php tests/restaurant-open-tests.php`
- `php tests/integration-test.php`


------
https://chatgpt.com/codex/tasks/task_e_68c82527e028832fa037b47be9989de2