### PR TITLE
Ensure date picker reinitializes after reset

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -897,6 +897,15 @@ jQuery(function($) {
       // Handle skeleton loading for specific steps (same as showStep but without scrolling)
       const stepId = $step.attr('id');
       
+      if (stepId === 'step-date' && fp === null) {
+        // Reinitialize the calendar to maintain the previous forceCalendarInteractivity safeguards
+        lazyLoadDatePicker().then(() => {
+          if (fp && typeof fp.open === 'function') {
+            fp.open();
+          }
+        });
+      }
+
       if (stepId === 'step-date' && $step.attr('data-skeleton') === 'true') {
         // Show skeleton initially, then lazy load date picker
         setTimeout(() => {


### PR DESCRIPTION
## Summary
- trigger lazy date picker initialization when revisiting the date step after a reset
- reopen the calendar once initialization completes to preserve interactivity safeguards

## Testing
- ./test-anchor-fix.sh

------
https://chatgpt.com/codex/tasks/task_e_68c82e6fb1cc832fadaa72a94dfc5dbd