### PR TITLE
Align front-end max advance default with settings and add regression test

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -40,7 +40,8 @@ function rbf_enqueue_frontend_assets() {
     
     if (!$has_booking_form) return;
 
-    $options = rbf_get_settings();
+    $default_settings = rbf_get_default_settings();
+    $options = wp_parse_args(rbf_get_settings(), $default_settings);
     $locale = rbf_current_lang(); // 'it' o 'en'
 
     // Flatpickr
@@ -103,7 +104,7 @@ function rbf_enqueue_frontend_assets() {
         'closedRanges' => $closed_specific['ranges'],
         'exceptions' => $closed_specific['exceptions'],
         'minAdvanceMinutes' => absint($options['min_advance_minutes'] ?? 0),
-        'maxAdvanceMinutes' => absint($options['max_advance_minutes'] ?? 10080),
+        'maxAdvanceMinutes' => absint($options['max_advance_minutes'] ?? $default_settings['max_advance_minutes']),
         'utilsScript' => 'https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/19.2.16/js/utils.js',
         'mealTooltips' => $meal_tooltips,
         'mealAvailability' => $meal_availability,

--- a/tests/regression-defaults-tests.php
+++ b/tests/regression-defaults-tests.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Regression tests for default booking window alignment
+ *
+ * Ensures that a fresh installation exposes the same
+ * max advance booking window on the PHP and JS sides.
+ */
+
+// Provide minimal WordPress stubs for standalone execution
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!defined('RBF_PLUGIN_DIR')) {
+    define('RBF_PLUGIN_DIR', dirname(__DIR__) . '/');
+}
+
+if (!defined('WP_CONTENT_DIR')) {
+    define('WP_CONTENT_DIR', sys_get_temp_dir());
+}
+
+if (!defined('RBF_VERSION')) {
+    define('RBF_VERSION', '1.0.0-test');
+}
+
+if (!function_exists('get_option')) {
+    function get_option($option, $default = false) {
+        return $default;
+    }
+}
+
+if (!function_exists('update_option')) {
+    function update_option($option, $value) {
+        return true;
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = []) {
+        if (is_object($args)) {
+            $args = get_object_vars($args);
+        }
+
+        if (!is_array($args)) {
+            $args = [$args];
+        }
+
+        return array_merge($defaults, $args);
+    }
+}
+
+if (!function_exists('absint')) {
+    function absint($maybeint) {
+        return abs(intval($maybeint));
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value) {
+        return $value;
+    }
+}
+
+if (!function_exists('sanitize_hex_color')) {
+    function sanitize_hex_color($color) {
+        if (!is_string($color)) {
+            return '';
+        }
+
+        $color = trim($color);
+        if (!preg_match('/^#([A-Fa-f0-9]{3}){1,2}$/', $color)) {
+            return '';
+        }
+
+        return strtolower($color);
+    }
+}
+
+if (!function_exists('sanitize_text_field')) {
+    function sanitize_text_field($value) {
+        if (is_scalar($value)) {
+            $value = preg_replace('/[\r\n\t\0\x0B]/', '', (string) $value);
+            return trim($value);
+        }
+
+        return '';
+    }
+}
+
+if (!function_exists('get_locale')) {
+    function get_locale() {
+        return 'it_IT';
+    }
+}
+
+require_once RBF_PLUGIN_DIR . 'includes/utils.php';
+
+/**
+ * Ensure the default max advance minutes matches the JS localization fallback.
+ */
+function test_rbf_default_max_advance_alignment() {
+    echo "Testing default max advance alignment...\n";
+
+    $defaults = rbf_get_default_settings();
+    $php_default = $defaults['max_advance_minutes'];
+
+    $frontend_path = RBF_PLUGIN_DIR . 'includes/frontend.php';
+    if (!file_exists($frontend_path)) {
+        echo "❌ Frontend file not found\n";
+        return false;
+    }
+
+    $frontend_content = file_get_contents($frontend_path);
+    $fallback_expr = null;
+
+    foreach (explode("\n", $frontend_content) as $line) {
+        if (strpos($line, "'maxAdvanceMinutes'") !== false) {
+            $parts = explode('??', $line, 2);
+            if (count($parts) !== 2) {
+                continue;
+            }
+
+            $candidate = trim($parts[1]);
+            $candidate = preg_replace('/[),\s]+$/', '', $candidate);
+
+            if ($candidate !== '') {
+                $fallback_expr = $candidate;
+                break;
+            }
+        }
+    }
+
+    if ($fallback_expr === null) {
+        echo "❌ Could not locate JS localization fallback for maxAdvanceMinutes\n";
+        return false;
+    }
+
+    $normalized_expr = preg_replace('/\s+/', '', $fallback_expr);
+
+    if (!preg_match('/^[A-Za-z0-9_\[\]\'"\$()]+$/', $normalized_expr) ||
+        strpos($normalized_expr, 'max_advance_minutes') === false) {
+        echo "❌ Unexpected fallback expression: {$fallback_expr}\n";
+        return false;
+    }
+
+    // Provide common variable aliases for evaluation
+    $default_settings = $defaults;
+
+    try {
+        // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.eval_eval
+        $evaluated = eval('return ' . $fallback_expr . ';');
+    } catch (Throwable $e) {
+        echo "❌ Failed to evaluate fallback expression: " . $e->getMessage() . "\n";
+        return false;
+    }
+
+    if ($evaluated !== $php_default) {
+        echo "❌ Mismatch detected: PHP default {$php_default} vs JS fallback {$evaluated}\n";
+        return false;
+    }
+
+    echo "✅ Defaults aligned: {$php_default} minutes\n\n";
+    return true;
+}
+
+if (defined('RBF_PLUGIN_DIR')) {
+    echo "Running Default Settings Regression Tests...\n";
+    echo "==========================================\n\n";
+
+    $result = test_rbf_default_max_advance_alignment();
+
+    if ($result) {
+        echo "🎉 All regression checks passed!\n";
+    } else {
+        echo "❌ Regression detected in default settings alignment.\n";
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure the front-end options merge plugin defaults before using max advance minutes and drop the hard-coded 10080 fallback
- add a regression test that validates the PHP and localized JS defaults stay aligned for fresh installs

## Testing
- php tests/regression-defaults-tests.php

------
https://chatgpt.com/codex/tasks/task_e_68c83cd56804832f87069966a8832093