### PR TITLE
Remove legacy onDateChange fallback handler

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -3754,30 +3754,6 @@ function initializeBookingForm($) {
     }
   }, 5000);
 
-  // Missing function implementations that are referenced in the code
-  
-  /**
-   * Handle date change from calendar or fallback input
-   */
-  function onDateChange(selectedDates) {
-    const dateValue = selectedDates && selectedDates.length > 0 ? 
-      formatLocalISO(selectedDates[0]) : 
-      el.dateInput.val();
-
-    if (dateValue) {
-      rbfLog.log('Date changed to: ' + dateValue);
-      resetSteps(2);
-      showStepWithoutScroll(el.timeStep, 3);
-      el.timeSelect.html('<option value="">' + ((rbfData && rbfData.labels && rbfData.labels.loading) || 'Caricamento...') + '</option>');
-      el.timeSelect.prop('disabled', true);
-      
-      const selectedMeal = el.mealRadios.filter(':checked').val();
-      if (selectedMeal) {
-        loadAvailableTimes(dateValue, selectedMeal);
-      }
-    }
-  }
-
   /**
    * Initialize international telephone input
    */


### PR DESCRIPTION
## Summary
- remove the legacy onDateChange fallback that invoked the nonexistent loadAvailableTimes helper so the primary date-change logic remains the only handler

## Testing
- browser_container.run_playwright_script (manual verification of date selection and time loading)


------
https://chatgpt.com/codex/tasks/task_e_68ca7ef40380832fa8226defebea785c