### PR TITLE
Ensure availability update waits for calendar init

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1967,8 +1967,15 @@ function initializeBookingForm($) {
    * Update availability data for specific meal
    */
   function updateAvailabilityDataForMeal(selectedMeal) {
-    if (!fp) return;
-    
+    if (!fp) {
+      lazyLoadDatePicker().then(() => {
+        if (fp) {
+          updateAvailabilityDataForMeal(selectedMeal);
+        }
+      });
+      return;
+    }
+
     try {
       // Get the current view date - use fp.now or fallback to current date
       const viewDate = fp.now || new Date();


### PR DESCRIPTION
## Summary
- defer availability refresh when the Flatpickr instance is not ready yet
- re-run the meal availability update once the calendar initializes

## Testing
- Manual Playwright verification of meal selection triggering availability AJAX and calendar color classes

------
https://chatgpt.com/codex/tasks/task_e_68ca85f22234832f9688bf3d55e73b4f