### PR TITLE
Remove duplicate tel input initializer

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -3788,31 +3788,4 @@ function initializeBookingForm($) {
     }
   }, 5000);
 
-  /**
-   * Initialize international telephone input
-   */
-  function initializeTelInput() {
-    if (iti || !el.telInput.length) return;
-
-    try {
-      if (typeof intlTelInput !== 'undefined') {
-        iti = intlTelInput(el.telInput[0], {
-          initialCountry: 'it',
-          preferredCountries: ['it', 'us', 'gb'],
-          separateDialCode: true,
-          formatOnDisplay: true,
-          autoHideDialCode: false,
-          nationalMode: false,
-          utilsScript: (rbfData && rbfData.utilsScript) || ''
-        });
-        
-        rbfLog.log('International telephone input initialized');
-      } else {
-        rbfLog.warn('intlTelInput not available, using fallback');
-      }
-    } catch (error) {
-      rbfLog.error('Failed to initialize international telephone input: ' + error.message);
-    }
-  }
-
 } // End of initializeBookingForm function


### PR DESCRIPTION
## Summary
- remove the duplicate initializeTelInput definition so the robust fallback-aware implementation is used everywhere

## Testing
- node - <<'NODE' (jsdom fallback verification)


------
https://chatgpt.com/codex/tasks/task_e_68ca98e66010832fa60f81c731d029b6