### PR TITLE
Add availability legend entries and visibility handling

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -1606,25 +1606,68 @@
 
 /* Exception legend for calendar */
 .rbf-exception-legend {
-    display: flex;
-    gap: 15px;
-    margin-top: 10px;
-    font-size: 12px;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px 20px;
+    margin-top: 12px;
+    font-size: 13px;
     color: var(--rbf-text-light);
-    flex-wrap: wrap;
+    background: var(--rbf-bg-light);
+    border-radius: var(--rbf-radius);
+    padding: 12px 16px;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 }
 
 .rbf-exception-legend-item {
     display: flex;
     align-items: center;
-    gap: 5px;
+    gap: 10px;
+    min-height: 24px;
+    line-height: 1.3;
 }
 
 .rbf-exception-legend-dot {
-    width: 8px;
-    height: 8px;
+    width: 12px;
+    height: 12px;
     border-radius: 50%;
     display: inline-block;
+    flex-shrink: 0;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.15);
+}
+
+.rbf-legend-availability-item span:last-child {
+    font-weight: 600;
+    color: var(--rbf-text);
+}
+
+.rbf-legend-availability-swatch {
+    width: 26px;
+    height: 16px;
+    border-radius: 4px;
+    display: inline-block;
+    flex-shrink: 0;
+    box-sizing: border-box;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+    border-left-width: 4px;
+    box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.7);
+    background: var(--rbf-bg-light);
+    overflow: hidden;
+}
+
+.rbf-legend-availability-swatch.rbf-availability-available {
+    background: linear-gradient(135deg, #f0fdf4 0%, #dcfce7 100%);
+    border-left-color: #16a34a;
+}
+
+.rbf-legend-availability-swatch.rbf-availability-limited {
+    background: linear-gradient(135deg, #fff7ed 0%, #fed7aa 100%);
+    border-left-color: #ea580c;
+}
+
+.rbf-legend-availability-swatch.rbf-availability-full {
+    background: linear-gradient(135deg, #fef2f2 0%, #fecaca 100%);
+    border-left-color: #dc2626;
 }
 
 /* Enhanced calendar day styling for exceptions */
@@ -1654,19 +1697,37 @@
         top: 1px !important;
         right: 1px !important;
     }
-    
+
     .rbf-exception-legend {
-        justify-content: center;
-        gap: 10px;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        padding: 12px;
+        gap: 10px 16px;
     }
-    
+
     .rbf-exception-legend-item {
-        font-size: 11px;
+        font-size: 12px;
     }
-    
+
     .rbf-exception-legend-dot {
         width: 10px;
         height: 10px;
+    }
+
+    .rbf-legend-availability-swatch {
+        width: 24px;
+        height: 14px;
+    }
+}
+
+@media (max-width: 480px) {
+    .rbf-exception-legend {
+        grid-template-columns: 1fr;
+        gap: 8px;
+        text-align: left;
+    }
+
+    .rbf-exception-legend-item {
+        justify-content: flex-start;
     }
 }
 

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -196,8 +196,9 @@ function rbf_enqueue_frontend_assets() {
             
             // Calendar availability labels
             'available' => rbf_translate_string('Disponibile'),
-            'limited' => rbf_translate_string('Limitato'),
-            'nearlyFull' => rbf_translate_string('Quasi pieno'),
+            'limited' => rbf_translate_string('Quasi al completo'),
+            'nearlyFull' => rbf_translate_string('Quasi al completo'),
+            'full' => rbf_translate_string('Completo'),
             'spotsRemaining' => rbf_translate_string('Posti rimasti:'),
             'occupancy' => rbf_translate_string('Occupazione:'),
             
@@ -632,8 +633,20 @@ function rbf_render_booking_form($atts = []) {
                             <input id="rbf-date" name="rbf_data" readonly="readonly" required aria-describedby="date-help" role="combobox" aria-expanded="false" aria-haspopup="grid" aria-label="<?php echo esc_attr(rbf_translate_string('Seleziona data prenotazione')); ?>">
                             <div id="rbf-date-error" class="rbf-field-error"></div>
                             <small id="date-help" class="rbf-help-text"><?php echo esc_html(rbf_translate_string('Seleziona una data dal calendario. Usa i tasti freccia per navigare, Invio per selezionare')); ?></small>
-                            <div class="rbf-exception-legend" style="display:none;" role="group" aria-labelledby="legend-label">
+                            <div class="rbf-exception-legend" style="display:none;" role="group" aria-labelledby="legend-label" aria-hidden="true">
                                 <div id="legend-label" class="sr-only"><?php echo esc_html(rbf_translate_string('Legenda calendario')); ?></div>
+                                <div class="rbf-exception-legend-item rbf-legend-availability-item">
+                                    <span class="rbf-legend-availability-swatch rbf-availability-available" role="img" aria-label="<?php echo esc_attr(rbf_translate_string('Indicatore disponibilità: Disponibile')); ?>"></span>
+                                    <span><?php echo esc_html(rbf_translate_string('Disponibile')); ?></span>
+                                </div>
+                                <div class="rbf-exception-legend-item rbf-legend-availability-item">
+                                    <span class="rbf-legend-availability-swatch rbf-availability-limited" role="img" aria-label="<?php echo esc_attr(rbf_translate_string('Indicatore disponibilità: Quasi al completo')); ?>"></span>
+                                    <span><?php echo esc_html(rbf_translate_string('Quasi al completo')); ?></span>
+                                </div>
+                                <div class="rbf-exception-legend-item rbf-legend-availability-item">
+                                    <span class="rbf-legend-availability-swatch rbf-availability-full" role="img" aria-label="<?php echo esc_attr(rbf_translate_string('Indicatore disponibilità: Completo')); ?>"></span>
+                                    <span><?php echo esc_html(rbf_translate_string('Completo')); ?></span>
+                                </div>
                                 <div class="rbf-exception-legend-item">
                                     <span class="rbf-exception-legend-dot" style="background: #20c997;" role="img" aria-label="<?php echo esc_attr(rbf_translate_string('Indicatore evento speciale')); ?>"></span>
                                     <span><?php echo esc_html(rbf_translate_string('Eventi Speciali')); ?></span>


### PR DESCRIPTION
## Summary
- add translated availability strings for all calendar statuses and extend the legend markup to cover availability indicators
- restyle the calendar legend for responsive layouts and add swatch styles that mirror the availability gradients
- ensure the legend appears when availability data is loaded and refine tooltip messaging for limited/nearly full/full states

## Testing
- php -l includes/frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68cac15205ec832f93f20935d5516699