### PR TITLE
Restore natural order for people selector controls

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -279,10 +279,6 @@
     color: #ccc;
 }
 
-.rbf-people-selector button:first-child {
-    order: 3; /* Move minus button to the right */
-}
-
 .rbf-people-selector input {
     flex: 1;
     min-height: 50px;
@@ -292,11 +288,6 @@
     font-size: 18px;
     color: var(--rbf-text);
     background: white;
-    order: 2;
-}
-
-.rbf-people-selector button:last-child {
-    order: 1; /* Move plus button to the left */
 }
 
 #rbf-submit {


### PR DESCRIPTION
## Summary
- remove the flexbox order overrides from the people selector controls so the minus button stays on the left and the plus button on the right
- keep the numeric input flex behavior unchanged to preserve focus styling and readability across templates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cac906b510832fa0c6f7faca0b6635