### PR TITLE
Fix intl-tel-input flag button accessibility

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1996,16 +1996,31 @@ function initializeBookingForm($) {
               // Rebuild flag selector button to prevent anchor jumps and improve accessibility
               const flagButton = el.telInput.closest('.iti').find('.iti__selected-flag');
               if (flagButton.length) {
-                flagButton
-                  .attr({
-                    role: 'button',
-                    title: rbfData.labels.selectPrefix || 'Seleziona prefisso',
-                    'aria-label': rbfData.labels.selectPrefix || 'Seleziona prefisso'
-                  })
-                  .on('click', function(e) {
-                    // Prevent the default anchor behavior which caused page jump
-                    e.preventDefault();
-                  });
+                const flagLabel = rbfData.labels.selectPrefix || 'Seleziona prefisso';
+
+                flagButton.attr({
+                  role: 'button',
+                  title: flagLabel,
+                  'aria-label': flagLabel,
+                  tabindex: flagButton.attr('tabindex') || '0'
+                });
+
+                const toggleDropdown = function(event) {
+                  if (event) {
+                    event.preventDefault();
+                  }
+
+                  if (iti && typeof iti.toggleCountryDropdown === 'function') {
+                    iti.toggleCountryDropdown();
+                  }
+                };
+
+                flagButton.on('click', toggleDropdown);
+                flagButton.on('keydown', function(event) {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    toggleDropdown(event);
+                  }
+                });
               }
 
             } else {


### PR DESCRIPTION
## Summary
- replace the intl-tel-input flag button click handler to call `toggleCountryDropdown`, preserving focus behavior and preventing jumps
- expose the flag as a proper button target with a default tabindex and keyboard handling for Enter/Space to keep the dropdown accessible

## Testing
- Playwright script against `frontend-test-complete.html` (served locally with bundled jQuery/intl-tel-input) to verify dropdown toggle and hidden country code updates
- Playwright script against `test-telephone-field.html` to confirm the reference template renders the flag selector and remains focusable

------
https://chatgpt.com/codex/tasks/task_e_68caca39b2fc832fab470eae0c23871e