### PR TITLE
Align people selector max with backend limit

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -146,20 +146,26 @@ function rbf_enqueue_frontend_assets() {
         $meal_availability[$meal['id']] = array_values(array_intersect($valid_day_keys, $available));
     }
 
+    $people_max = absint($options['max_people'] ?? 0);
+    if ($people_max <= 0) {
+        $people_max = 20;
+    }
+
     wp_localize_script('rbf-frontend-js', 'rbfData', [
         'ajaxUrl' => admin_url('admin-ajax.php'),
         'nonce' => wp_create_nonce('rbf_ajax_nonce'),
         'locale' => $locale, // it/en
         'debug' => defined('WP_DEBUG') && WP_DEBUG, // Enable debug mode if WP_DEBUG is on
-        
+
         // RENEWED: Enhanced data validation to ensure arrays are always arrays
         'closedDays' => rbf_ensure_array($closed_days),
         'closedSingles' => rbf_ensure_array($closed_specific['singles'] ?? []),
         'closedRanges' => rbf_ensure_array($closed_specific['ranges'] ?? []),
         'exceptions' => rbf_ensure_array($closed_specific['exceptions'] ?? []),
-        
+
         'minAdvanceMinutes' => max(0, absint($options['min_advance_minutes'] ?? 0)),
         'maxAdvanceMinutes' => max(0, absint($options['max_advance_minutes'] ?? $default_settings['max_advance_minutes'])),
+        'peopleMax' => $people_max,
         'utilsScript' => plugin_dir_url(dirname(__FILE__)) . 'assets/js/vendor/intl-tel-input-utils.js',
         
         // RENEWED: Enhanced meal data validation
@@ -182,7 +188,7 @@ function rbf_enqueue_frontend_assets() {
             'dateInPast' => rbf_translate_string('La data selezionata non può essere nel passato.'),
             'timeRequired' => rbf_translate_string('Seleziona un orario per continuare.'),
             'peopleMinimum' => rbf_translate_string('Il numero di persone deve essere almeno 1.'),
-            'peopleMaximum' => rbf_translate_string('Il numero di persone non può superare 20.'),
+            'peopleMaximum' => sprintf(rbf_translate_string('Il numero di persone non può superare %d.'), $people_max),
             'nameRequired' => rbf_translate_string('Il nome deve contenere almeno 2 caratteri.'),
             'nameInvalid' => rbf_translate_string('Il nome può contenere solo lettere, spazi, apostrofi e trattini.'),
             'surnameRequired' => rbf_translate_string('Il cognome deve contenere almeno 2 caratteri.'),

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -393,6 +393,7 @@ function rbf_translate_string($text) {
         'ID GA4 non valido. Deve essere nel formato G-XXXXXXXXXX.' => 'Invalid GA4 ID. Must be in format G-XXXXXXXXXX.',
         'ID GTM non valido. Deve essere nel formato GTM-XXXXXXX.' => 'Invalid GTM ID. Must be in format GTM-XXXXXXX.',
         'Il numero di persone deve essere compreso tra 1 e 20.' => 'The number of people must be between 1 and 20.',
+        'Il numero di persone non può superare %d.' => 'The number of people cannot exceed %d.',
         'Spiacenti, non ci sono abbastanza posti. Rimasti: %d. Scegli un altro orario.' => 'Sorry, there are not enough seats available. Remaining: %d. Please choose another time.',
 
         // Frontend


### PR DESCRIPTION
## Summary
- expose the configured maximum people count to the frontend script via localized data
- use the localized people cap in the booking form controls and validation logic with a 20 person fallback
- update translation handling so the maximum people validation message reflects the active limit

## Testing
- php -l includes/frontend.php
- php -l includes/utils.php

------
https://chatgpt.com/codex/tasks/task_e_68cace115d00832f81cf711ad49a447e