### PR TITLE
Ensure GA4 funnel tracking detects booking shortcodes

### DIFF
--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -17,28 +17,8 @@ add_action('wp_enqueue_scripts', 'rbf_enqueue_frontend_assets');
 function rbf_enqueue_frontend_assets() {
     global $post;
     if (!is_singular() || !$post) return;
-    
-    // Check for any booking form shortcode
-    $booking_shortcodes = [
-        'ristorante_booking_form',
-        'anniversary_booking_form',
-        'birthday_booking_form', 
-        'romantic_booking_form',
-        'celebration_booking_form',
-        'business_booking_form',
-        'proposal_booking_form',
-        'special_booking_form'
-    ];
-    
-    $has_booking_form = false;
-    foreach ($booking_shortcodes as $shortcode) {
-        if (has_shortcode($post->post_content, $shortcode)) {
-            $has_booking_form = true;
-            break;
-        }
-    }
-    
-    if (!$has_booking_form) return;
+
+    if (!rbf_post_has_booking_form($post)) return;
 
     $default_settings = rbf_get_default_settings();
     $options = wp_parse_args(rbf_get_settings(), $default_settings);

--- a/includes/ga4-funnel-tracking.php
+++ b/includes/ga4-funnel-tracking.php
@@ -129,16 +129,17 @@ function rbf_is_gtm_hybrid_mode() {
  * Check if current page has booking form
  */
 function rbf_is_booking_page() {
-    // Check if we're on a page/post that contains the booking shortcode
+    if (!function_exists('is_singular') || !is_singular()) {
+        return false;
+    }
+
     global $post;
-    
+
     if (!$post) {
         return false;
     }
-    
-    // Check if post content contains the booking shortcode
-    return has_shortcode($post->post_content, 'rbf_form') || 
-           has_shortcode($post->post_content, 'restaurant_booking_form');
+
+    return rbf_post_has_booking_form($post);
 }
 
 /**

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -11,6 +11,70 @@ if (!defined('ABSPATH')) {
 }
 
 /**
+ * Retrieve all booking form shortcodes handled by the plugin.
+ *
+ * Having a centralized list keeps script enqueues and integrations
+ * synchronized with the shortcodes registered on the frontend.
+ *
+ * @return array List of shortcode tags.
+ */
+function rbf_get_booking_form_shortcodes() {
+    $shortcodes = [
+        'ristorante_booking_form',
+        'anniversary_booking_form',
+        'birthday_booking_form',
+        'romantic_booking_form',
+        'celebration_booking_form',
+        'business_booking_form',
+        'proposal_booking_form',
+        'special_booking_form',
+    ];
+
+    // Maintain backward compatibility with legacy shortcode names.
+    $legacy_shortcodes = [
+        'rbf_form',
+        'restaurant_booking_form',
+    ];
+
+    $shortcodes = array_merge($shortcodes, $legacy_shortcodes);
+
+    /**
+     * Filter the list of booking form shortcodes.
+     *
+     * @param array $shortcodes Default list of booking form shortcodes.
+     */
+    return apply_filters('rbf_booking_form_shortcodes', array_values(array_unique($shortcodes)));
+}
+
+/**
+ * Determine if the supplied post content includes a booking form shortcode.
+ *
+ * @param WP_Post|int|null $post Optional post object or ID to inspect.
+ * @return bool True if a booking shortcode is present, false otherwise.
+ */
+function rbf_post_has_booking_form($post = null) {
+    if (!function_exists('has_shortcode')) {
+        return false;
+    }
+
+    if (!($post instanceof WP_Post)) {
+        $post = get_post($post);
+    }
+
+    if (!$post || empty($post->post_content)) {
+        return false;
+    }
+
+    foreach (rbf_get_booking_form_shortcodes() as $shortcode) {
+        if (has_shortcode($post->post_content, $shortcode)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
  * Conditional debug logger for the plugin.
  * Logs messages only when WP_DEBUG or RBF_FORCE_LOG is enabled.
  *


### PR DESCRIPTION
## Summary
- add helper functions that centralize the list of booking shortcodes and detection logic
- reuse the helper when enqueuing frontend assets so any booking form triggers scripts
- update GA4 booking page detection to honor all registered booking shortcodes

## Testing
- php -l includes/utils.php
- php -l includes/frontend.php
- php -l includes/ga4-funnel-tracking.php

------
https://chatgpt.com/codex/tasks/task_e_68cad4c7550c832f84b6be17b0454eb9