### PR TITLE
Fix availability transient cleanup pattern

### DIFF
--- a/fp-prenotazioni-ristorante-pro.php
+++ b/fp-prenotazioni-ristorante-pro.php
@@ -55,10 +55,12 @@ function rbf_clear_transients() {
     }
 
     // Also clear specific availability transients
+    $availability_pattern = $wpdb->esc_like('_transient_rbf_avail_') . '%';
+
     $deleted_avail = $wpdb->query(
         $wpdb->prepare(
             "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-            $wpdb->esc_like('_transient_rbf_avail_%')
+            $availability_pattern
         )
     );
     


### PR DESCRIPTION
## Summary
- ensure the availability transient cleanup builds the wildcard pattern the same way as the other transient loops
- reuse the escaped prefix plus % wildcard so DELETE queries match `_transient_rbf_avail_*` entries reliably

## Testing
- php -l fp-prenotazioni-ristorante-pro.php
- Manual sqlite3 query confirming `_transient_rbf_avail_*` options are deleted with the new pattern
- php /tmp/test_clear.php (stubbed wpdb harness exercising rbf_clear_transients)


------
https://chatgpt.com/codex/tasks/task_e_68cad8135010832f94b3be20cb1df795