### PR TITLE
Restore Brevo segmentation fallback to form language

### DIFF
--- a/docs/BREVO_SEGMENTATION_ENHANCEMENT.md
+++ b/docs/BREVO_SEGMENTATION_ENHANCEMENT.md
@@ -1,36 +1,36 @@
 # Brevo List Segmentation Enhancement
 
 ## Overview
-Simplified the Brevo list segmentation to use only the phone prefix (country code) when determining which Brevo list to use for customer contacts.
+Restored Brevo list segmentation to evaluate the submitted form language first and then apply the Italian phone override. This keeps Italian-speaking users on the Italian automation even when they enter a foreign phone number, while still prioritising Italian numbers when present.
 
 ## Previous Behavior
-- Segmentation was based on both phone prefix and form compilation language
+- Segmentation relied solely on the phone prefix (country code)
 - Italian phone prefix (+39) → Italian Brevo list
-- Non-Italian phone prefix + Italian form → Italian Brevo list
-- Non-Italian phone prefix + English form → English Brevo list
+- Any non-Italian phone prefix → English Brevo list
 
 ## New Behavior
-Simplified logic based only on phone prefix:
-1. **If phone prefix is Italian (+39)** → Use Italian Brevo list
-2. **If phone prefix is NOT Italian** → Use English Brevo list (regardless of form language)
+Updated logic that blends form language with phone prefix:
+1. Determine the default list from the form language (Italian forms default to the Italian list, English forms default to the English list)
+2. If the detected phone prefix is Italian (+39), override to the Italian list regardless of form language
+3. If the phone prefix is not Italian, keep the language-driven default from step 1
 
 ## Test Cases
 | Form Language | Phone Prefix | Brevo List | Reason |
 |---------------|--------------|------------|---------|
+| English | Italian (+39) | Italian | Italian phone overrides form |
 | Italian | Italian (+39) | Italian | Italian phone |
-| English | Italian (+39) | Italian | Italian phone |
-| Italian | UK (+44) | English | Non-Italian phone |
-| English | UK (+44) | English | Non-Italian phone |
-| Italian | US (+1) | English | Non-Italian phone |
-| English | US (+1) | English | Non-Italian phone |
+| Italian | UK (+44) | Italian | Italian form default |
+| English | UK (+44) | English | English form default |
+| Italian | US (+1) | Italian | Italian form default |
+| English | US (+1) | English | English form default |
 
 ## Files Modified
-- `includes/booking-handler.php` - Simplified Brevo list segmentation logic
+- `includes/booking-handler.php` - Restored blended segmentation logic
 - `includes/integrations.php` - Added documentation comments
 - `tests/brevo-segmentation-test.php` - Updated test suite
 - `docs/BREVO_SEGMENTATION_ENHANCEMENT.md` - Updated documentation
 
 ## Implementation Details
-The enhancement is implemented in the `rbf_validate_request()` helper, where the `$brevo_lang` variable is determined. The new logic uses only the phone prefix for segmentation, making the system simpler and more predictable.
+The enhancement is implemented in the `rbf_validate_request()` helper, where the `$brevo_lang` variable is determined. The refreshed logic normalises the form language, applies it as the baseline segmentation value, and then enforces the Italian phone override when needed.
 
-This ensures clear segmentation based on phone country codes, with all non-Italian phone numbers directed to the English list.
+This keeps Brevo automations aligned with how the booking forms are localised while still guaranteeing that Italian phone numbers always receive the Italian communication flow.

--- a/includes/email-failover.php
+++ b/includes/email-failover.php
@@ -155,7 +155,7 @@ class RBF_Email_Failover_Service {
                 $data['time'],
                 $data['people'],
                 $data['notes'],
-                $data['lang'],
+                $data['brevo_lang'] ?? $data['lang'],
                 $data['tel'],
                 $data['marketing'],
                 $data['meal']
@@ -493,9 +493,9 @@ function rbf_get_email_failover_service() {
 /**
  * Send customer notification with failover
  */
-function rbf_send_customer_notification_with_failover($first_name, $last_name, $email, $date, $time, $people, $notes, $lang, $tel, $marketing, $meal, $booking_id = null, $special_type = '', $special_label = '') {
+function rbf_send_customer_notification_with_failover($first_name, $last_name, $email, $date, $time, $people, $notes, $brevo_lang, $form_lang, $tel, $marketing, $meal, $booking_id = null, $special_type = '', $special_label = '') {
     $service = rbf_get_email_failover_service();
-    
+
     $notification_data = [
         'type' => 'customer_notification',
         'booking_id' => $booking_id,
@@ -506,21 +506,23 @@ function rbf_send_customer_notification_with_failover($first_name, $last_name, $
         'time' => $time,
         'people' => $people,
         'notes' => $notes,
-        'lang' => $lang,
+        'lang' => $brevo_lang,
+        'brevo_lang' => $brevo_lang,
+        'form_lang' => $form_lang,
         'tel' => $tel,
         'marketing' => $marketing,
         'meal' => $meal,
         'special_type' => $special_type,
         'special_label' => $special_label
     ];
-    
+
     return $service->send_notification($notification_data);
 }
 
 /**
  * Send admin notification with failover
  */
-function rbf_send_admin_notification_with_failover($first_name, $last_name, $email, $date, $time, $people, $notes, $tel, $meal, $booking_id = null, $special_type = '', $special_label = '') {
+function rbf_send_admin_notification_with_failover($first_name, $last_name, $email, $date, $time, $people, $notes, $tel, $meal, $brevo_lang, $form_lang, $booking_id = null, $special_type = '', $special_label = '') {
     $options = rbf_get_settings();
     $restaurant_email = $options['notification_email'];
     $webmaster_email = $options['webmaster_email'];
@@ -600,6 +602,8 @@ HTML;
         'notes' => $notes,
         'tel' => $tel,
         'meal' => $meal,
+        'brevo_lang' => $brevo_lang,
+        'form_lang' => $form_lang,
         'special_type' => $special_type,
         'special_label' => $special_label
     ];


### PR DESCRIPTION
## Summary
- derive Brevo list language from the submitted form language and keep the Italian phone override in the booking handler
- pass both the computed Brevo language and the raw form language through the failover notification pipeline
- refresh Brevo segmentation docs and tests to cover the Italian phone, Italian form with foreign phone, and English form scenarios

## Testing
- php -l includes/booking-handler.php
- php -l includes/email-failover.php
- php -l tests/brevo-segmentation-test.php

------
https://chatgpt.com/codex/tasks/task_e_68cb23221bcc832f872465e0b5e0eba2