### PR TITLE
Add GA4 client ID support for funnel tracking

### DIFF
--- a/tests/ga4-funnel-tests.php
+++ b/tests/ga4-funnel-tests.php
@@ -213,13 +213,28 @@ class RBF_GA4_Funnel_Tests {
             );
             
             $this->assert_true(
-                isset($transient_data['event_params']) && 
+                isset($transient_data['event_params']) &&
                 $transient_data['event_params']['value'] == 75.50,
                 "Transient should contain correct event parameters"
             );
-            
+
+            $this->assert_true(
+                !empty($transient_data['client_id']),
+                "Completion tracking should persist GA client ID"
+            );
+
+            $this->assert_true(
+                !empty($transient_data['event_id']),
+                "Completion tracking should store event ID for deduplication"
+            );
+
+            $this->assert_true(
+                ($transient_data['event_name'] ?? '') === 'booking_confirmed',
+                "Completion tracking should expose booking_confirmed event name"
+            );
+
             $this->test_results[$test_name] = ['status' => 'PASS', 'message' => 'Booking completion tracking working correctly'];
-            
+
         } catch (Exception $e) {
             $this->test_results[$test_name] = ['status' => 'FAIL', 'message' => $e->getMessage()];
         }


### PR DESCRIPTION
## Summary
- capture the GA4 client ID in the funnel tracker, persist it for reuse, and include it in AJAX requests while reusing server-provided booking completion payloads
- resolve, store, and forward the GA4 client ID on the server side for Measurement Protocol events, including booking completion responses
- extend the GA4 funnel test expectations to cover the stored client ID, event ID, and event name

## Testing
- php -l includes/ga4-funnel-tracking.php

------
https://chatgpt.com/codex/tasks/task_e_68cb24ac5138832fa79ec99ce3e1f104