### PR TITLE
Trigger calendar cache refresh when bookings are saved

### DIFF
--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -339,6 +339,22 @@ function rbf_create_booking_post($data, $redirect_url, $anchor) {
         }
     }
 
+    $booking_context = array_merge(
+        $data,
+        [
+            'post_id'          => $post_id,
+            'table_assignment' => $table_assignment,
+        ]
+    );
+
+    /**
+     * Fires immediately after a booking post has been created.
+     *
+     * @param int   $post_id         The ID of the booking post.
+     * @param array $booking_context Booking context data.
+     */
+    do_action('rbf_booking_created', $post_id, $booking_context);
+
     delete_transient('rbf_avail_' . $date . '_' . $slot);
     $options = rbf_get_settings();
 

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1399,13 +1399,24 @@ function rbf_clear_calendar_cache($date = null, $meal = null) {
 }
 
 // Hook into booking creation/modification to clear cache
-add_action('rbf_booking_created', function($booking_id) {
-    $date = get_post_meta($booking_id, 'rbf_data', true);
-    $meal = get_post_meta($booking_id, 'rbf_meal', true);
+add_action('rbf_booking_created', function($booking_id, $booking_context = []) {
+    $date = '';
+    $meal = '';
+
+    if (is_array($booking_context)) {
+        $date = $booking_context['date'] ?? '';
+        $meal = $booking_context['meal'] ?? '';
+    }
+
+    if (empty($date) || empty($meal)) {
+        $date = get_post_meta($booking_id, 'rbf_data', true);
+        $meal = get_post_meta($booking_id, 'rbf_meal', true);
+    }
+
     if ($date && $meal) {
         rbf_clear_calendar_cache($date, $meal);
     }
-});
+}, 10, 2);
 
 add_action('rbf_booking_status_changed', function($booking_id, $new_status, $old_status) {
     $date = get_post_meta($booking_id, 'rbf_data', true);


### PR DESCRIPTION
## Summary
- fire the `rbf_booking_created` action immediately after saving a booking and expose relevant context for listeners
- update the front-end cache listener to use the provided booking context before falling back to post meta so the calendar cache is cleared consistently

## Testing
- php -l includes/booking-handler.php
- php -l includes/frontend.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb31e8648832facda71e01c19cd73