### PR TITLE
Disable intl-tel-input search and style simplified dropdown

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -785,6 +785,47 @@
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12), 0 0 0 3px rgba(0, 0, 0, 0.1);
 }
 
+/* Simplified dropdown variant without search field */
+.rbf-iti-simple .iti__search-container,
+.rbf-iti-simple .iti__search-input {
+    display: none !important;
+}
+
+.rbf-iti-simple .iti__dropdown-content {
+    padding: 8px 0;
+    width: min(320px, 90vw) !important;
+    max-height: min(320px, 60vh);
+}
+
+.rbf-iti-simple .iti__country-list {
+    padding: 4px 0;
+    margin: 0;
+    width: min(320px, 90vw) !important;
+    max-height: min(280px, 55vh);
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.rbf-iti-simple .iti__country {
+    padding: 10px 16px;
+}
+
+@media (max-width: 768px) {
+    .rbf-iti-simple .iti__dropdown-content {
+        width: min(280px, 92vw) !important;
+        max-height: min(260px, 50vh);
+    }
+
+    .rbf-iti-simple .iti__country-list {
+        width: min(280px, 92vw) !important;
+        max-height: min(240px, 50vh);
+    }
+
+    .rbf-iti-simple .iti__country {
+        padding: 12px 18px;
+    }
+}
+
 /* Add visual indicator for fallback mode */
 .rbf-tel-fallback::before {
     content: "⚠️ ";

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -1962,11 +1962,66 @@ function initializeBookingForm($) {
             });
 
             if (iti) {
+              const itiWrapper = el.telInput.closest('.iti');
+
+              const findDropdownContainer = () => {
+                const instanceId = el.telInput.attr('data-intl-tel-input-id');
+                if (!instanceId) {
+                  return $();
+                }
+
+                return $(`.iti.iti--container[data-intl-tel-input-id="${instanceId}"]`);
+              };
+
+              const hideSearchWithinScope = ($scope) => {
+                if (!$scope || !$scope.length) {
+                  return;
+                }
+
+                $scope.addClass('rbf-iti-simple');
+
+                const searchContainer = $scope.find('.iti__search-container');
+                if (searchContainer.length) {
+                  searchContainer.attr('aria-hidden', 'true');
+                  searchContainer.find('input, button').each(function() {
+                    const $element = $(this);
+                    $element.attr('tabindex', '-1');
+                    $element.attr('aria-hidden', 'true');
+                    $element.prop('disabled', true);
+                  });
+                  searchContainer.hide();
+                }
+
+                $scope.find('.iti__search-input').each(function() {
+                  const $searchInput = $(this);
+                  $searchInput.attr('tabindex', '-1');
+                  $searchInput.attr('aria-hidden', 'true');
+                  $searchInput.prop('disabled', true);
+                  $searchInput.val('');
+                  $searchInput.trigger('blur');
+                  $searchInput.hide();
+                });
+              };
+
+              const disableDropdownSearch = () => {
+                hideSearchWithinScope(itiWrapper);
+
+                const dropdownContainer = findDropdownContainer();
+                if (dropdownContainer.length) {
+                  hideSearchWithinScope(dropdownContainer);
+                }
+              };
+
+              disableDropdownSearch();
+              setTimeout(disableDropdownSearch, 0);
+              setTimeout(disableDropdownSearch, 250);
+              setTimeout(disableDropdownSearch, 500);
+
               // Enhanced event handling
               el.telInput[0].addEventListener('countrychange', function() {
                 const countryData = iti.getSelectedCountryData();
                 $('#rbf_country_code').val(countryData.iso2);
-                
+
                 // Announce to screen readers
                 announceToScreenReader(`Country selected: ${countryData.name}`);
               });
@@ -1974,14 +2029,21 @@ function initializeBookingForm($) {
               // Enhanced dropdown handling
               el.telInput[0].addEventListener('open:countrydropdown', function() {
                 // Ensure proper z-index
-                const dropdown = document.querySelector('.iti__country-list');
-                if (dropdown) {
-                  dropdown.style.zIndex = '9999';
+                const dropdownContainer = findDropdownContainer();
+                if (dropdownContainer.length) {
+                  dropdownContainer.css('z-index', '9999');
+                  const dropdownList = dropdownContainer.find('.iti__country-list');
+                  if (dropdownList.length) {
+                    dropdownList.css('z-index', '9999');
+                  }
                 }
+
+                disableDropdownSearch();
+                setTimeout(disableDropdownSearch, 0);
               });
-              
+
               el.telInput[0].addEventListener('close:countrydropdown', function() {
-                // Dropdown closed
+                disableDropdownSearch();
               });
               
               // Improved validation feedback


### PR DESCRIPTION
## Summary
- hide the intl-tel-input search field during initialization and ensure the dropdown container inherits the new simplified class
- guard the hidden search input from focus, keep the dropdown accessible, and retune the z-index handling
- add dedicated styles for the simplified dropdown variant to control spacing, width, and max height responsively

## Testing
- not run (manual browser verification recommended)


------
https://chatgpt.com/codex/tasks/task_e_68cc4afdd994832f86c8b8f92f7ebcea