### PR TITLE
Allow ignoring booking when validating slot capacity

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -3245,7 +3245,13 @@ function rbf_move_booking_callback() {
     }
     
     // Check availability for new slot
-    $availability_check = rbf_check_slot_availability($new_date, $meal, $new_time, $people);
+    $availability_check = rbf_check_slot_availability(
+        $new_date,
+        $meal,
+        $new_time,
+        $people,
+        ($booking && $booking->post_type === 'rbf_booking') ? $booking_id : null
+    );
     if (!$availability_check) {
         wp_send_json_error('Nuovo slot non disponibile');
     }


### PR DESCRIPTION
## Summary
- extend the slot availability helper so it can ignore a specific booking when evaluating capacity for the same meal/date
- ensure the weekly staff drag & drop AJAX callback passes the booking identifier into the helper
- expand the weekly drag & drop CLI test script with configurable capacity usage and a full-capacity same-meal regression scenario

## Testing
- php tests/weekly-staff-drag-drop-tests.php

------
https://chatgpt.com/codex/tasks/task_e_68cc69ddff6c832fae9f60b8565d0f6d