### PR TITLE
Fix booking sum meal fallback

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1720,10 +1720,11 @@ function rbf_sum_active_bookings($date, $meal_id) {
          FROM {$wpdb->posts} p
          INNER JOIN {$wpdb->postmeta} pm_people ON p.ID = pm_people.post_id AND pm_people.meta_key = 'rbf_persone'
          INNER JOIN {$wpdb->postmeta} pm_date ON p.ID = pm_date.post_id AND pm_date.meta_key = 'rbf_data'
-         INNER JOIN {$wpdb->postmeta} pm_meal ON p.ID = pm_meal.post_id AND pm_meal.meta_key = 'rbf_meal'
+         LEFT JOIN {$wpdb->postmeta} pm_meal ON p.ID = pm_meal.post_id AND pm_meal.meta_key = 'rbf_meal'
+         LEFT JOIN {$wpdb->postmeta} pm_meal_legacy ON p.ID = pm_meal_legacy.post_id AND pm_meal_legacy.meta_key = 'rbf_orario'
          LEFT JOIN {$wpdb->postmeta} pm_status ON p.ID = pm_status.post_id AND pm_status.meta_key = 'rbf_booking_status'
          WHERE p.post_type = 'rbf_booking' AND p.post_status = 'publish'
-         AND pm_date.meta_value = %s AND pm_meal.meta_value = %s
+         AND pm_date.meta_value = %s AND COALESCE(pm_meal.meta_value, pm_meal_legacy.meta_value) = %s
          AND COALESCE(pm_status.meta_value, 'confirmed') <> 'cancelled'
     ";
 


### PR DESCRIPTION
## Summary
- join the legacy `rbf_orario` meta when summing active bookings so meals missing `rbf_meal` still count
- continue filtering cancelled bookings and rely on the same COALESCE fallback used by analytics queries

## Testing
- php tests/optimistic-locking-tests.php
- php tests/buffer-overbooking-tests.php
- php tests/integration-optimistic-locking.php *(fails: missing WordPress bootstrap for rbf_sum_active_bookings)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f58e939c832f90548a7fad964b19