### PR TITLE
Enforce privacy consent acceptance

### DIFF
--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -84,6 +84,13 @@ function rbf_validate_request($post, $redirect_url, $anchor) {
         'rbf_marketing'      => 'text'
     ]);
 
+    $privacy_raw = $sanitized_fields['rbf_privacy'] ?? '';
+    if ($privacy_raw !== 'yes') {
+        rbf_handle_error(rbf_translate_string('È necessario accettare l\'informativa sulla privacy per proseguire.'), 'privacy_validation', $redirect_url . $anchor);
+        return false;
+    }
+    $privacy = 'yes';
+
     $meal = $sanitized_fields['rbf_meal'];
     $date = $sanitized_fields['rbf_data'];
     $time_data = $sanitized_fields['rbf_orario'];
@@ -137,8 +144,6 @@ function rbf_validate_request($post, $redirect_url, $anchor) {
         $brevo_lang = 'it';
     }
 
-    $privacy_raw   = $sanitized_fields['rbf_privacy'] ?? 'no';
-    $privacy   = ($privacy_raw === 'yes' || $privacy_raw === 'no') ? $privacy_raw : 'no';
     $marketing_raw = $sanitized_fields['rbf_marketing'] ?? 'no';
     $marketing = ($marketing_raw === 'yes' || $marketing_raw === 'no') ? $marketing_raw : 'no';
 


### PR DESCRIPTION
## Summary
- add a server-side validation that requires explicit privacy consent before continuing the booking flow
- normalise the stored privacy value to `yes` only after passing validation while keeping marketing consent sanitisation intact

## Testing
- `php -l includes/booking-handler.php`
- `php -r 'define("ABSPATH", true); function add_action($hook, $callback) {} function wp_verify_nonce($nonce, $action) { return true; } function rbf_detect_bot_submission($post) { return ["is_bot" => false, "reason" => "", "severity" => "low"]; } function rbf_log($message) {} function rbf_get_settings() { return []; } function rbf_verify_recaptcha($token) { return ["success" => true, "reason" => ""]; } function rbf_handle_error($message, $context = "general", $redirect_url = null) { echo "ERROR: $message\n"; } function rbf_translate_string($string) { return $string; } function rbf_sanitize_input_fields($post, $rules) { $sanitized = []; foreach ($rules as $key => $type) { if (isset($post[$key])) { $sanitized[$key] = $post[$key]; } } return $sanitized; } function rbf_get_valid_meal_ids() { return ["dinner"]; } function rbf_get_people_max_limit() { return 10; } function rbf_validate_email($email) { return $email; } function rbf_validate_phone($phone) { return $phone; } function rbf_detect_source($data) { return "web"; } require "includes/booking-handler.php"; $post = ["rbf_nonce" => "nonce", "rbf_meal" => "dinner", "rbf_data" => "2024-01-01", "rbf_orario" => "slot|20:00", "rbf_persone" => 2, "rbf_nome" => "Mario", "rbf_cognome" => "Rossi", "rbf_email" => "mario@example.com", "rbf_tel" => "+3900000000", "rbf_privacy" => "no"]; var_dump(rbf_validate_request($post, "https://example.com", "#form"));'`

------
https://chatgpt.com/codex/tasks/task_e_68d117429c84832f8d720d0c64d530a0