### PR TITLE
Fix calendar tooltip positioning with scroll offsets

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -994,18 +994,20 @@ function initializeBookingForm($) {
       const tooltipRect = tooltip.getBoundingClientRect();
       const viewportWidth = window.innerWidth;
       const viewportHeight = window.innerHeight;
+      const scrollX = window.scrollX || document.documentElement.scrollLeft;
+      const scrollY = window.scrollY || document.documentElement.scrollTop;
 
-      let left = rect.left + rect.width / 2 - tooltipRect.width / 2;
-      let top = rect.top - tooltipRect.height - 10;
+      let left = rect.left + scrollX + rect.width / 2 - tooltipRect.width / 2;
+      let top = rect.top + scrollY - tooltipRect.height - 10;
 
-      if (left < 10) {
-        left = 10;
-      } else if (left + tooltipRect.width > viewportWidth - 10) {
-        left = viewportWidth - tooltipRect.width - 10;
+      if (left < scrollX + 10) {
+        left = scrollX + 10;
+      } else if (left + tooltipRect.width > scrollX + viewportWidth - 10) {
+        left = scrollX + viewportWidth - tooltipRect.width - 10;
       }
 
-      if (top < 10) {
-        top = rect.bottom + 10;
+      if (top < scrollY + 10) {
+        top = rect.bottom + scrollY + 10;
         tooltip.classList.add('rbf-tooltip-below');
       }
 


### PR DESCRIPTION
## Summary
- include window scroll offsets when calculating calendar availability tooltip coordinates
- clamp tooltip positions using the scrolled viewport bounds and update below placement logic

## Testing
- Manual tooltip hover after scrolling (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68d166606868832f9e36ad9ee1f087f7