### PR TITLE
Fix people selector buttons styling

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -2485,6 +2485,39 @@
     box-shadow: none;
 }
 
+/* Restore compact layout for the people selector controls */
+.rbf-people-selector > button {
+    width: 50px;
+    height: 50px;
+    min-width: 50px;
+    min-height: 50px;
+    padding: 0;
+    margin: 0;
+    border: none;
+    border-radius: 0;
+    background: var(--rbf-bg-light);
+    color: var(--rbf-primary);
+    font-size: 20px;
+    font-weight: bold;
+    line-height: 1;
+    flex: 0 0 50px;
+}
+
+.rbf-people-selector > button:hover:not(:disabled) {
+    background: var(--rbf-primary);
+    color: white;
+    transform: none;
+    box-shadow: none;
+}
+
+.rbf-people-selector > button:disabled {
+    background: #f8f8f8;
+    color: #ccc;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
 /* Checkbox and radio accessibility */
 .rbf-form input[type="checkbox"],
 .rbf-form input[type="radio"] {


### PR DESCRIPTION
## Summary
- restore the compact styling of the people selector controls after the global accessible button rules
- keep the accessible button presentation for the other form buttons while preventing layout shifts on the selector

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d16acc223c832f984fef05292ddbe9