### PR TITLE
Restrict accessible button styling to exclude people selector

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -2455,7 +2455,7 @@
 }
 
 /* Accessible button styling */
-.rbf-form button,
+.rbf-form button:not(.rbf-people-selector button),
 .rbf-form input[type="submit"] {
     min-height: 44px;
     padding: 12px 24px;
@@ -2469,14 +2469,14 @@
     color: white;
 }
 
-.rbf-form button:hover,
+.rbf-form button:not(.rbf-people-selector button):hover,
 .rbf-form input[type="submit"]:hover {
     background: var(--rbf-primary-light);
     transform: translateY(-1px);
     box-shadow: var(--rbf-shadow-hover);
 }
 
-.rbf-form button:disabled,
+.rbf-form button:not(.rbf-people-selector button):disabled,
 .rbf-form input[type="submit"]:disabled {
     background: var(--rbf-border);
     color: var(--rbf-text-light);


### PR DESCRIPTION
## Summary
- limit the global accessible button selector to ignore the people selector controls so their compact layout remains intact
- keep hover and disabled variants scoped to the updated selector so the ± buttons retain their dedicated styling while other controls preserve accessibility tweaks

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d171896acc832fac14f5f524323c70