### PR TITLE
Use configured people limit in AI suggestions AJAX validation

### DIFF
--- a/AI_SUGGESTIONS_DOCUMENTATION.md
+++ b/AI_SUGGESTIONS_DOCUMENTATION.md
@@ -52,7 +52,7 @@ function rbf_get_alternative_suggestions($date, $meal, $people, $requested_time 
 #### Input Validation
 - Date format validation (Y-m-d)
 - Meal type validation against active meals
-- Party size constraints (1-20 people)
+- Party size constraints based on the configured maximum capacity
 
 #### Availability Checks
 - Restaurant opening hours
@@ -78,7 +78,7 @@ $suggestion['preference_score'] = base_score - (distance_penalty * multiplier);
 **Parameters**:
 - `$date` (string): Original requested date (Y-m-d)
 - `$meal` (string): Meal type identifier
-- `$people` (int): Number of people (1-20)
+- `$people` (int): Number of people (must respect the configured limit)
 - `$requested_time` (string): Original time for context (optional)
 
 **Returns**: Array of suggestion objects

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -559,6 +559,7 @@ function rbf_translate_string($text) {
         'Il numero di persone deve essere compreso tra 1 e %d.' => 'The number of people must be between 1 and %d.',
         'Il numero di persone deve essere compreso tra 1 e 20.' => 'The number of people must be between 1 and 20.',
         'Il numero di persone non può superare %d.' => 'The number of people cannot exceed %d.',
+        'Parametri non validi: è consentito un massimo di %d persone.' => 'Invalid parameters: maximum allowed is %d guests.',
         'Errore durante l\'aggiornamento della capacità della prenotazione.' => 'Error while updating the booking capacity.',
         'Spiacenti, non ci sono abbastanza posti. Rimasti: %d. Scegli un altro orario.' => 'Sorry, there are not enough seats available. Remaining: %d. Please choose another time.',
 


### PR DESCRIPTION
## Summary
- load the booking settings inside the AI suggestions AJAX callback to determine the configured people limit and validate requests against it with a tailored error
- translate the new validation string and refresh the AI suggestions documentation to describe the dynamic limit
- adjust the AI suggestions admin test to derive its request size from the configured maximum

## Testing
- php -l includes/ai-suggestions.php
- php -l includes/utils.php
- php -l tests/ai-suggestions-tests.php

------
https://chatgpt.com/codex/tasks/task_e_68d19abf1344832f9ec5facdc283f7cf