### PR TITLE
Protect GA4 booking completion data with token verification

### DIFF
--- a/assets/js/ga4-funnel-tracking.js
+++ b/assets/js/ga4-funnel-tracking.js
@@ -712,7 +712,8 @@
     if (window.location.search.includes('rbf_success=1')) {
         const urlParams = new URLSearchParams(window.location.search);
         const bookingId = urlParams.get('booking_id');
-        
+        const bookingToken = urlParams.get('booking_token');
+
         // Check if we have booking data from server (if AJAX is available)
         if (bookingId && typeof $.ajax === 'function') {
             $.ajax({
@@ -721,6 +722,7 @@
                 data: {
                     action: 'rbf_get_booking_completion_data',
                     booking_id: bookingId,
+                    booking_token: bookingToken || '',
                     nonce: rbfGA4Funnel.nonce
                 },
                 success: function(response) {

--- a/includes/booking-handler.php
+++ b/includes/booking-handler.php
@@ -573,7 +573,8 @@ function rbf_send_notifications($data, $context) {
             'currency'=> 'EUR',
             'meal'    => $meal,
             'people'  => $people,
-            'bucket'  => $src['bucket']
+            'bucket'  => $src['bucket'],
+            'tracking_token' => $context['tracking_token'] ?? ''
         ];
         rbf_track_booking_completion($post_id, $tracking_completion_data);
     }

--- a/tests/ga4-funnel-tests.php
+++ b/tests/ga4-funnel-tests.php
@@ -138,9 +138,10 @@ class RBF_GA4_Funnel_Tests {
                 'currency' => 'EUR',
                 'meal' => 'cena',
                 'people' => 2,
-                'bucket' => 'organic'
+                'bucket' => 'organic',
+                'tracking_token' => 'testtoken123'
             ];
-            
+
             // This should not throw errors
             rbf_track_booking_completion(123, $booking_data);
             
@@ -199,11 +200,12 @@ class RBF_GA4_Funnel_Tests {
                 'currency' => 'EUR',
                 'meal' => 'pranzo',
                 'people' => 3,
-                'bucket' => 'gads'
+                'bucket' => 'gads',
+                'tracking_token' => 'token456'
             ];
-            
+
             rbf_track_booking_completion($booking_id, $booking_data);
-            
+
             // Check if transient was set
             $transient_data = get_transient('rbf_ga4_completion_' . $booking_id);
             
@@ -216,6 +218,11 @@ class RBF_GA4_Funnel_Tests {
                 isset($transient_data['event_params']) &&
                 $transient_data['event_params']['value'] == 75.50,
                 "Transient should contain correct event parameters"
+            );
+
+            $this->assert_true(
+                isset($transient_data['tracking_token']) && $transient_data['tracking_token'] === 'token456',
+                'Transient should persist the tracking token for verification'
             );
 
             $this->assert_true(


### PR DESCRIPTION
## Summary
- include the booking tracking token in the GA4 completion transient and require it for AJAX retrieval, clearing it after a successful response
- forward the tracking token from the booking handler and client-side GA4 funnel script so secure lookups can succeed
- adjust GA4 funnel tests to exercise the new token handling path

## Testing
- php -l includes/booking-handler.php
- php -l includes/ga4-funnel-tracking.php

------
https://chatgpt.com/codex/tasks/task_e_68d1a62ac274832f85cd7cfa5407d570