### PR TITLE
Improve wizard initialization accessibility

### DIFF
--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -108,12 +108,17 @@
 
 .rbf-step {
     margin-bottom: 2rem;
-    opacity: 0;
-    transform: translateY(20px);
+    opacity: 1;
+    transform: none;
     transition: var(--rbf-transition);
 }
 
-.rbf-step.active {
+.rbf-form--initialized .rbf-step {
+    opacity: 0;
+    transform: translateY(20px);
+}
+
+.rbf-form--initialized .rbf-step.active {
     opacity: 1;
     transform: translateY(0);
 }
@@ -2592,7 +2597,9 @@
         scroll-behavior: auto !important;
     }
     
-    .rbf-step {
+    .rbf-step,
+    .rbf-form--initialized .rbf-step,
+    .rbf-form--initialized .rbf-step.active {
         transition: none;
         opacity: 1;
         transform: none;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -245,6 +245,13 @@ function initializeBookingForm($) {
     submitButton: form.find('#rbf-submit')
   };
 
+  // Ensure progressive steps are hidden until the wizard is fully initialized
+  el.dateStep.hide();
+  el.timeStep.hide();
+  el.peopleStep.hide();
+  el.detailsStep.hide();
+  el.submitButton.hide().prop('disabled', true);
+
   function applyPeopleLimitAttributes() {
     if (!el.peopleInput.length) {
       return;
@@ -2400,6 +2407,9 @@ function initializeBookingForm($) {
     }
     updateProgressIndicator(fromStep);
   }
+
+  // Initialize the wizard flow with only the first step visible
+  resetSteps(1);
 
   /**
    * Handle meal selection change - RENEWED with complete calendar refresh
@@ -4591,6 +4601,9 @@ function initializeBookingForm($) {
       return 'Emergency fix applied. Try clicking calendar dates now.';
     }
   };
+
+  // Mark the form as initialized to enable wizard-specific styles
+  form.addClass('rbf-form--initialized');
 
   // Add a console helper for users (only in debug mode)
   if (isDebugMode || (typeof WP_DEBUG !== 'undefined' && WP_DEBUG)) {

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -725,7 +725,7 @@ function rbf_render_booking_form($atts = []) {
                     </div>
                 </div>
 
-                <div id="step-time" class="rbf-step" style="display:none;" role="group" aria-labelledby="time-label" data-skeleton="true">
+                <div id="step-time" class="rbf-step" role="group" aria-labelledby="time-label" data-skeleton="true">
                     <div class="rbf-field-wrapper">
                         <label id="time-label" for="rbf-time"><?php echo esc_html(rbf_translate_string('Orario')); ?><span class="rbf-required-indicator">*</span></label>
                         
@@ -758,7 +758,7 @@ function rbf_render_booking_form($atts = []) {
                     </div>
                 </div>
 
-                <div id="step-people" class="rbf-step" style="display:none;" role="group" aria-labelledby="people-label" data-skeleton="true">
+                <div id="step-people" class="rbf-step" role="group" aria-labelledby="people-label" data-skeleton="true">
                     <div class="rbf-field-wrapper">
                         <label id="people-label"><?php echo esc_html(rbf_translate_string('Persone')); ?><span class="rbf-required-indicator">*</span></label>
                         
@@ -783,7 +783,7 @@ function rbf_render_booking_form($atts = []) {
                     </div>
                 </div>
 
-                <div id="step-details" class="rbf-step" style="display:none;" role="group" aria-labelledby="details-label" data-skeleton="true">
+                <div id="step-details" class="rbf-step" role="group" aria-labelledby="details-label" data-skeleton="true">
                     <h3 id="details-label" class="rbf-section-title"><?php echo esc_html(rbf_translate_string('I tuoi dati')); ?></h3>
                     
                     <!-- Skeleton for form fields -->
@@ -901,7 +901,7 @@ function rbf_render_booking_form($atts = []) {
                     <label for="rbf_website">Website (leave blank):</label>
                     <input type="text" name="rbf_website" id="rbf_website" value="" tabindex="-1" autocomplete="off">
                 </div>
-                <button id="rbf-submit" type="submit" style="display:none;"><?php echo esc_html(rbf_translate_string('Prenota')); ?></button>
+                <button id="rbf-submit" type="submit"><?php echo esc_html(rbf_translate_string('Prenota')); ?></button>
             </form>
         <?php endif; ?>
         


### PR DESCRIPTION
## Summary
- remove inline display rules from later steps so the booking form remains accessible without JavaScript
- update the frontend stylesheet to keep steps visible by default and only apply transition effects after the form is initialized
- adjust the booking JavaScript to hide steps programmatically, reset the wizard state on load, and add the new initialization class to the form

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d39bcc0f5c832f8803a0d475051e0c