### PR TITLE
Invalidate availability caches after settings update

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -429,6 +429,18 @@ function rbf_sanitize_settings_callback($input) {
 }
 
 /**
+ * Clear availability caches whenever the main settings option is updated.
+ */
+add_action('update_option_rbf_settings', 'rbf_clear_availability_caches_on_settings_update', 10, 2);
+function rbf_clear_availability_caches_on_settings_update($old_value, $value) {
+    if ($old_value === $value) {
+        return;
+    }
+
+    rbf_delete_transients_like(rbf_get_global_availability_transient_patterns());
+}
+
+/**
  * Enqueue admin styles
  */
 add_action('admin_enqueue_scripts','rbf_enqueue_admin_styles');

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -1507,8 +1507,6 @@ function rbf_ajax_get_availability() {
  * Clear calendar cache when bookings are modified
  */
 function rbf_clear_calendar_cache($date = null, $meal = null) {
-    global $wpdb;
-
     $patterns = [];
 
     if ($date && $meal) {
@@ -1527,24 +1525,10 @@ function rbf_clear_calendar_cache($date = null, $meal = null) {
             '_transient_timeout_rbf_avail_' . $date . '_' . $meal,
         ];
     } else {
-        $patterns = [
-            '_transient_rbf_cal_avail_',
-            '_transient_timeout_rbf_cal_avail_',
-            '_transient_rbf_times_',
-            '_transient_timeout_rbf_times_',
-            '_transient_rbf_avail_',
-            '_transient_timeout_rbf_avail_',
-        ];
+        $patterns = rbf_get_global_availability_transient_patterns();
     }
 
-    foreach ($patterns as $pattern) {
-        $wpdb->query(
-            $wpdb->prepare(
-                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
-                $wpdb->esc_like($pattern) . '%'
-            )
-        );
-    }
+    rbf_delete_transients_like($patterns);
 }
 
 // Hook into booking creation/modification to clear cache

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -528,6 +528,49 @@ function rbf_get_settings() {
 }
 
 /**
+ * Retrieve the availability transient patterns used across the plugin.
+ *
+ * @return array
+ */
+function rbf_get_global_availability_transient_patterns() {
+    return [
+        '_transient_rbf_cal_avail_',
+        '_transient_timeout_rbf_cal_avail_',
+        '_transient_rbf_times_',
+        '_transient_timeout_rbf_times_',
+        '_transient_rbf_avail_',
+        '_transient_timeout_rbf_avail_',
+    ];
+}
+
+/**
+ * Delete transients whose option names match the provided patterns.
+ *
+ * @param array $patterns List of option name prefixes to delete.
+ * @return void
+ */
+function rbf_delete_transients_like(array $patterns) {
+    global $wpdb;
+
+    if (!isset($wpdb) || empty($wpdb->options)) {
+        return;
+    }
+
+    foreach ($patterns as $pattern) {
+        if (!is_string($pattern) || $pattern === '') {
+            continue;
+        }
+
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+                $wpdb->esc_like($pattern) . '%'
+            )
+        );
+    }
+}
+
+/**
  * Get the maximum number of people allowed for a booking.
  *
  * Returns the highest configured meal capacity when no explicit legacy override is present.


### PR DESCRIPTION
## Summary
- add shared helpers to list availability transient patterns and remove matching transients
- reuse the helper inside `rbf_clear_calendar_cache()` to centralize cache invalidation
- hook into `update_option_rbf_settings` to purge availability caches whenever settings are saved

## Testing
- php -l includes/utils.php
- php -l includes/frontend.php
- php -l includes/admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d39f00a144832fa87675da4d07457f