### PR TITLE
Harden plugin for production deployment

### DIFF
--- a/fp-prenotazioni-ristorante-pro.php
+++ b/fp-prenotazioni-ristorante-pro.php
@@ -24,6 +24,21 @@ define('RBF_VERSION', '1.5');
 require_once RBF_PLUGIN_DIR . 'includes/utils.php';
 
 /**
+ * Load plugin translations.
+ *
+ * Executed early on the `plugins_loaded` hook to ensure translation files are
+ * available before other modules register strings.
+ */
+function rbf_load_textdomain() {
+    if (!function_exists('load_plugin_textdomain') || !function_exists('plugin_basename')) {
+        return;
+    }
+
+    load_plugin_textdomain('rbf', false, dirname(plugin_basename(__FILE__)) . '/languages/');
+}
+add_action('plugins_loaded', 'rbf_load_textdomain', -10);
+
+/**
  * Clear all transients used by the plugin.
  */
 function rbf_clear_transients() {
@@ -116,9 +131,40 @@ function rbf_load_modules() {
 // Use 'plugins_loaded' hook instead of 'init' to load earlier
 add_action('plugins_loaded', 'rbf_load_modules', 0);
 
+if (!function_exists('rbf_should_load_admin_tests')) {
+    /**
+     * Determine whether developer test harnesses should be loaded.
+     *
+     * Tests are only loaded in explicitly enabled environments to avoid
+     * accidental execution on production sites.
+     *
+     * @return bool
+     */
+    function rbf_should_load_admin_tests() {
+        $should_load = false;
+
+        if (defined('RBF_ENABLE_ADMIN_TESTS')) {
+            $should_load = (bool) RBF_ENABLE_ADMIN_TESTS;
+        } elseif (defined('WP_DEBUG') && WP_DEBUG && function_exists('wp_get_environment_type')) {
+            $environment = wp_get_environment_type();
+            $should_load = in_array($environment, ['local', 'development'], true);
+        }
+
+        if (function_exists('apply_filters')) {
+            return (bool) apply_filters('rbf_should_load_admin_tests', $should_load);
+        }
+
+        return (bool) $should_load;
+    }
+}
+
 // Load test files in admin context
 if (is_admin()) {
     add_action('plugins_loaded', function() {
+        if (!rbf_should_load_admin_tests()) {
+            return;
+        }
+
         $test_files = [
             'ga4-funnel-tests.php',
             'ai-suggestions-tests.php',
@@ -163,5 +209,97 @@ register_deactivation_hook(__FILE__, 'rbf_deactivate_plugin');
 function rbf_deactivate_plugin() {
     // Clean up rewrite rules
     flush_rewrite_rules();
+}
+
+register_uninstall_hook(__FILE__, 'rbf_uninstall_plugin');
+
+function rbf_uninstall_cleanup_site() {
+    if (function_exists('wp_clear_scheduled_hook')) {
+        wp_clear_scheduled_hook('rbf_update_booking_statuses');
+    }
+
+    $options = ['rbf_settings', 'rbf_admin_notices', 'rbf_plugin_version'];
+    foreach ($options as $option_name) {
+        delete_option($option_name);
+    }
+
+    if (function_exists('get_posts') && function_exists('wp_delete_post')) {
+        $booking_ids = get_posts([
+            'post_type'              => 'rbf_booking',
+            'post_status'            => 'any',
+            'numberposts'            => -1,
+            'fields'                 => 'ids',
+            'no_found_rows'          => true,
+            'update_post_meta_cache' => false,
+            'update_post_term_cache' => false,
+        ]);
+
+        foreach ($booking_ids as $booking_id) {
+            wp_delete_post($booking_id, true);
+        }
+    }
+
+    global $wpdb;
+    if (!isset($wpdb)) {
+        return;
+    }
+
+    $tables = [
+        $wpdb->prefix . 'rbf_areas',
+        $wpdb->prefix . 'rbf_tables',
+        $wpdb->prefix . 'rbf_table_groups',
+        $wpdb->prefix . 'rbf_table_group_members',
+        $wpdb->prefix . 'rbf_table_assignments',
+        $wpdb->prefix . 'rbf_slot_versions',
+        $wpdb->prefix . 'rbf_email_notifications',
+    ];
+
+    foreach ($tables as $table) {
+        $wpdb->query("DROP TABLE IF EXISTS `{$table}`");
+    }
+
+    $transient_patterns = [
+        '_transient_rbf_',
+        '_transient_timeout_rbf_',
+    ];
+
+    foreach ($transient_patterns as $pattern) {
+        $wpdb->query(
+            $wpdb->prepare(
+                "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s",
+                $wpdb->esc_like($pattern) . '%'
+            )
+        );
+    }
+}
+
+function rbf_uninstall_plugin() {
+    if (!function_exists('current_user_can') || !current_user_can('activate_plugins')) {
+        return;
+    }
+
+    $is_multisite = function_exists('is_multisite') && is_multisite();
+
+    if ($is_multisite && function_exists('get_sites') && function_exists('switch_to_blog') && function_exists('restore_current_blog')) {
+        $site_ids = get_sites(['fields' => 'ids']);
+        foreach ($site_ids as $site_id) {
+            switch_to_blog($site_id);
+            rbf_uninstall_cleanup_site();
+            restore_current_blog();
+        }
+
+        if (function_exists('delete_site_option')) {
+            $network_options = ['rbf_settings', 'rbf_admin_notices', 'rbf_plugin_version'];
+            foreach ($network_options as $option_name) {
+                delete_site_option($option_name);
+            }
+        }
+    } else {
+        rbf_uninstall_cleanup_site();
+    }
+
+    if (function_exists('wp_cache_flush')) {
+        wp_cache_flush();
+    }
 }
 

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -706,8 +706,30 @@ function rbf_get_people_max_limit($settings = null) {
  * Translate strings to English
  */
 function rbf_translate_string($text) {
+    if (!is_scalar($text)) {
+        $text = '';
+    }
+
+    $original = (string) $text;
+
+    if (function_exists('__')) {
+        $wp_translated = __($original, 'rbf');
+        if ($wp_translated !== $original) {
+            if (function_exists('apply_filters')) {
+                $wp_translated = apply_filters('rbf_translate_string', $wp_translated, $original);
+            }
+            return $wp_translated;
+        }
+    }
+
     $locale = rbf_current_lang();
-    if ($locale !== 'en') return $text;
+    if ($locale !== 'en') {
+        $result = $original;
+        if (function_exists('apply_filters')) {
+            $result = apply_filters('rbf_translate_string', $result, $original);
+        }
+        return $result;
+    }
 
     static $translations = [
         // Backend UI
@@ -1083,7 +1105,13 @@ function rbf_translate_string($text) {
         'Non ci sono orari disponibili per questa data, ma abbiamo trovato delle alternative!' => 'No times available for this date, but we found alternatives!',
         'Non ci sono orari disponibili per questa data.' => 'No times available for this date.',
     ];
-    return $translations[$text] ?? $text;
+    $result = $translations[$original] ?? $original;
+
+    if (function_exists('apply_filters')) {
+        $result = apply_filters('rbf_translate_string', $result, $original);
+    }
+
+    return $result;
 }
 
 /**

--- a/languages/index.php
+++ b/languages/index.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Silence is golden.
+ */
+


### PR DESCRIPTION
## Summary
- load the plugin text domain early and add a languages directory stub so WordPress can discover translations
- guard admin test harness files behind explicit environment checks to avoid running them in production
- implement an uninstall cleanup routine that removes custom data, options and scheduled events across single and multisite installs

## Testing
- php -l fp-prenotazioni-ristorante-pro.php
- php -l includes/utils.php
- php -l languages/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d4291a67a0832fb6e66d26adb9ccc6