### PR TITLE
Hardening export workflow

### DIFF
--- a/includes/utils.php
+++ b/includes/utils.php
@@ -751,6 +751,13 @@ function rbf_translate_string($text) {
         'Pagina del modulo di prenotazione' => 'Booking form page',
         'Seleziona una pagina' => 'Select a page',
         'Utilizzata per i link di conferma generati dal backend. Se vuota, il plugin tenta di individuarla automaticamente.' => 'Used for backend confirmation links. If left empty the plugin will try to detect it automatically.',
+        'Non hai le autorizzazioni per esportare le prenotazioni.' => 'You do not have permission to export bookings.',
+        'Data di inizio non valida. Usa il formato YYYY-MM-DD.' => 'Invalid start date. Use the YYYY-MM-DD format.',
+        'Data di fine non valida. Usa il formato YYYY-MM-DD.' => 'Invalid end date. Use the YYYY-MM-DD format.',
+        'La data di fine non può essere precedente alla data di inizio.' => 'The end date cannot be earlier than the start date.',
+        'Formato export non supportato.' => 'Export format not supported.',
+        'Stato selezionato non valido.' => 'Selected status is not valid.',
+        'Nessuna prenotazione trovata per il periodo selezionato.' => 'No bookings found for the selected period.',
 
         // New configurable meals system
         'Configurazione Pasti' => 'Meal Configuration',


### PR DESCRIPTION
## Summary
- guard the admin export page with capability checks and robust validation of export inputs
- normalize and validate requested date ranges and statuses before building the booking export query
- surface localized feedback for invalid requests and reuse the new strings in the translation map

## Testing
- php -l includes/admin.php
- php -l includes/utils.php

------
https://chatgpt.com/codex/tasks/task_e_68d43647843c832f9fc1b8680f8f20be