### PR TITLE
Improve activation and deactivation robustness

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -2581,7 +2581,6 @@ function rbf_auto_complete_past_bookings() {
 /**
  * Clear scheduled events on plugin deactivation
  */
-register_deactivation_hook(RBF_PLUGIN_FILE, 'rbf_clear_automatic_status_events');
 function rbf_clear_automatic_status_events() {
     wp_clear_scheduled_hook('rbf_update_booking_statuses');
 }


### PR DESCRIPTION
## Summary
- ensure activation tasks run for every site when the plugin is network-activated
- reuse activation helper to register CPTs, tables, cron and version for each site context
- centralize deactivation cleanup to avoid duplicate hook registration and clear scheduled events safely

## Testing
- php -l fp-prenotazioni-ristorante-pro.php
- php -l includes/admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d437fca388832f91c2c864b73835a4