### PR TITLE
Add directory index guards for production hardening

### DIFF
--- a/assets/css/index.php
+++ b/assets/css/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;

--- a/assets/index.php
+++ b/assets/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;

--- a/assets/js/index.php
+++ b/assets/js/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;

--- a/assets/vendor/flatpickr/index.php
+++ b/assets/vendor/flatpickr/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;

--- a/assets/vendor/index.php
+++ b/assets/vendor/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;

--- a/assets/vendor/intl-tel-input/index.php
+++ b/assets/vendor/intl-tel-input/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;

--- a/includes/index.php
+++ b/includes/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;

--- a/tests/index.php
+++ b/tests/index.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * Prevents direct directory access on misconfigured servers.
+ */
+exit;


### PR DESCRIPTION
## Summary
- add "silence is golden" index.php guards across public plugin folders to avoid directory listings

## Testing
- `php -l includes/index.php`
- `for file in assets/index.php assets/css/index.php assets/js/index.php assets/vendor/index.php assets/vendor/flatpickr/index.php assets/vendor/intl-tel-input/index.php tests/index.php; do php -l $file; done`


------
https://chatgpt.com/codex/tasks/task_e_68d45af9cc98832fb5adafda81ff8259