### PR TITLE
Add WP-CLI test email command for failover validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,32 @@ git clone https://github.com/franpass87/FP-Prenotazioni-Ristorante-PRO.git
 
 > 📚 **Documentazione Build**: Vedi [GITHUB_ACTIONS_WORKFLOWS.md](GITHUB_ACTIONS_WORKFLOWS.md) per dettagli sui workflows automatici
 
+## 🧰 Comandi WP-CLI
+
+Il plugin fornisce diversi comandi WP-CLI per gestire rapidamente l'ambiente di produzione:
+
+```bash
+# Verifica dei requisiti minimi
+wp rbf check-environment
+
+# Controllo/riparazione schema database prenotazioni
+wp rbf verify-schema
+
+# Svuotamento cache/transient del plugin
+wp rbf clear-cache
+
+# Ripianificazione del cron di aggiornamento prenotazioni
+wp rbf reschedule-cron
+
+# Pulizia log email più vecchi della retention configurata
+wp rbf purge-email-logs [--days=<giorni>]
+
+# Invio email di test tramite sistema di failover
+wp rbf test-email [--email=destinatario] [--force]
+```
+
+Questi strumenti permettono di validare rapidamente la configurazione (cron, schema DB, notifiche) prima del go-live.
+
 ## ⚙️ Configurazione
 
 > ⚠️ **Importante / Important:** dopo l'installazione non sono presenti pasti preconfigurati. Vai in **Prenotazioni → Impostazioni → Configurazione Pasti** e crea manualmente i servizi (es. Pranzo, Cena, Aperitivo) prima di utilizzare il modulo di prenotazione: il form frontend mostrerà le opzioni solo dopo aver salvato almeno un pasto attivo.


### PR DESCRIPTION
## Summary
- add a `wp rbf test-email` WP-CLI subcommand to fire a test notification through the Brevo/wp_mail failover pipeline and surface provider/log details
- document all available plugin CLI utilities in the README for easier production readiness validation

## Testing
- php -l includes/wp-cli.php

------
https://chatgpt.com/codex/tasks/task_e_68d5044af5e4832fa27d39ea117a1703