### PR TITLE
Add regression test for admin menu visibility

### DIFF
--- a/.github/workflows/build-wordpress-plugin.yml
+++ b/.github/workflows/build-wordpress-plugin.yml
@@ -49,7 +49,7 @@ jobs:
 
         rsync -a --prune-empty-dirs \
           --include='*/' \
-          --include='${PLUGIN_SLUG}.php' \
+          --include="${PLUGIN_SLUG}.php" \
           --include='fppr-brand.json' \
           --include='README.md' \
           --include='*.md' \

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -159,10 +159,10 @@ function rbf_create_bookings_menu() {
     $booking_capability  = rbf_get_booking_capability();
     $settings_capability = rbf_get_settings_capability();
 
-    add_menu_page(rbf_translate_string('Calendario & Agenda'), rbf_translate_string('Calendario & Agenda'), $booking_capability, 'rbf_calendar', 'rbf_calendar_page_html', 'dashicons-calendar-alt', 20);
+    add_menu_page(rbf_translate_string('FP Prenotazioni Ristorante'), rbf_translate_string('FP Prenotazioni Ristorante'), $booking_capability, 'rbf_calendar', 'rbf_calendar_page_html', 'dashicons-calendar-alt', 20);
     add_submenu_page('rbf_calendar', rbf_translate_string('Calendario'), rbf_translate_string('Calendario'), $booking_capability, 'rbf_calendar', 'rbf_calendar_page_html');
     add_submenu_page('rbf_calendar', rbf_translate_string('Agenda Settimanale'), rbf_translate_string('Agenda'), $booking_capability, 'rbf_weekly_staff', 'rbf_weekly_staff_page_html');
-    add_submenu_page('rbf_calendar', rbf_translate_string('Inserimento Manuale'), rbf_translate_string('Inserimento Manuale'), $booking_capability, 'rbf_add_booking', 'rbf_add_booking_page_html');
+    add_submenu_page('rbf_calendar', rbf_translate_string('Nuova Prenotazione Manuale'), rbf_translate_string('Nuova Prenotazione Manuale'), $booking_capability, 'rbf_add_booking', 'rbf_add_booking_page_html');
     add_submenu_page('rbf_calendar', rbf_translate_string('Gestione Tavoli'), rbf_translate_string('Gestione Tavoli'), $booking_capability, 'rbf_tables', 'rbf_tables_page_html');
     add_submenu_page('rbf_calendar', rbf_translate_string('Report & Analytics'), rbf_translate_string('Report & Analytics'), $booking_capability, 'rbf_reports', 'rbf_reports_page_html');
     add_submenu_page('rbf_calendar', rbf_translate_string('Notifiche Email'), rbf_translate_string('Notifiche Email'), $settings_capability, 'rbf_email_notifications', 'rbf_email_notifications_page_html');

--- a/includes/utils.php
+++ b/includes/utils.php
@@ -1083,6 +1083,7 @@ function rbf_translate_string($text) {
     static $translations = [
         // Backend UI
         'Apri pagina di conferma' => 'Open confirmation page',
+        'FP Prenotazioni Ristorante' => 'FP Restaurant Bookings',
         'Prenotazioni' => 'Bookings',
         'Tutte le Prenotazioni' => 'All Bookings',
         'Prenotazione' => 'Booking',
@@ -1090,6 +1091,11 @@ function rbf_translate_string($text) {
         'Aggiungi Nuova Prenotazione' => 'Add New Booking',
         'Modifica Prenotazione' => 'Edit Booking',
         'Nuova Prenotazione' => 'New Booking',
+        'Nuova Prenotazione Manuale' => 'New Manual Booking',
+        'Agenda Settimanale' => 'Weekly Agenda',
+        'Agenda' => 'Agenda',
+        'Gestione Tavoli' => 'Table Management',
+        'Notifiche Email' => 'Email Notifications',
         'Visualizza Prenotazione' => 'View Booking',
         'Cerca Prenotazioni' => 'Search Bookings',
         'Nessuna Prenotazione trovata' => 'No bookings found',

--- a/tests/admin-menu-visibility-tests.php
+++ b/tests/admin-menu-visibility-tests.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Basic regression test to ensure the admin menu exposes all key pages.
+ */
+declare(strict_types=1);
+
+error_reporting(E_ALL);
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__);
+}
+
+if (!function_exists('__')) {
+    function __($text, $domain = null)
+    {
+        return $text;
+    }
+}
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value)
+    {
+        return $value;
+    }
+}
+
+if (!function_exists('add_action')) {
+    function add_action($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        $GLOBALS['rbf_registered_hooks'][] = [$hook, $callback, $priority, $accepted_args];
+        return true;
+    }
+}
+
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1)
+    {
+        $GLOBALS['rbf_registered_filters'][] = [$hook, $callback, $priority, $accepted_args];
+        return true;
+    }
+}
+
+if (!function_exists('get_locale')) {
+    function get_locale()
+    {
+        return 'it_IT';
+    }
+}
+
+$GLOBALS['rbf_menu_pages'] = [];
+if (!function_exists('add_menu_page')) {
+    function add_menu_page($page_title, $menu_title, $capability, $menu_slug, $callback = '', $icon_url = '', $position = null)
+    {
+        $entry = [
+            'page_title' => $page_title,
+            'menu_title' => $menu_title,
+            'capability' => $capability,
+            'menu_slug'  => $menu_slug,
+            'callback'   => $callback,
+            'icon_url'   => $icon_url,
+            'position'   => $position,
+        ];
+        $GLOBALS['rbf_menu_pages'][] = $entry;
+
+        return 'toplevel_page_' . $menu_slug;
+    }
+}
+
+$GLOBALS['rbf_submenu_pages'] = [];
+if (!function_exists('add_submenu_page')) {
+    function add_submenu_page($parent_slug, $page_title, $menu_title, $capability, $menu_slug, $callback = '')
+    {
+        $entry = [
+            'parent_slug' => $parent_slug,
+            'page_title'  => $page_title,
+            'menu_title'  => $menu_title,
+            'capability'  => $capability,
+            'menu_slug'   => $menu_slug,
+            'callback'    => $callback,
+        ];
+        $GLOBALS['rbf_submenu_pages'][] = $entry;
+
+        return $menu_slug;
+    }
+}
+
+require_once __DIR__ . '/../includes/utils.php';
+require_once __DIR__ . '/../includes/admin.php';
+
+rbf_create_bookings_menu();
+
+$top_level = $GLOBALS['rbf_menu_pages'][0] ?? null;
+if ($top_level === null) {
+    throw new RuntimeException('Top-level menu was not registered.');
+}
+
+$expected_top_level = [
+    'page_title' => 'FP Prenotazioni Ristorante',
+    'menu_title' => 'FP Prenotazioni Ristorante',
+    'capability' => 'rbf_manage_bookings',
+    'menu_slug'  => 'rbf_calendar',
+];
+
+foreach ($expected_top_level as $key => $expected_value) {
+    $actual = $top_level[$key] ?? null;
+    if ($actual !== $expected_value) {
+        throw new RuntimeException(sprintf(
+            'Expected top-level menu %s to be "%s" but found "%s".',
+            $key,
+            $expected_value,
+            $actual ?? '(missing)'
+        ));
+    }
+}
+
+$expected_submenus = [
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Calendario',
+        'menu_title'  => 'Calendario',
+        'capability'  => 'rbf_manage_bookings',
+        'menu_slug'   => 'rbf_calendar',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Agenda Settimanale',
+        'menu_title'  => 'Agenda',
+        'capability'  => 'rbf_manage_bookings',
+        'menu_slug'   => 'rbf_weekly_staff',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Nuova Prenotazione Manuale',
+        'menu_title'  => 'Nuova Prenotazione Manuale',
+        'capability'  => 'rbf_manage_bookings',
+        'menu_slug'   => 'rbf_add_booking',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Gestione Tavoli',
+        'menu_title'  => 'Gestione Tavoli',
+        'capability'  => 'rbf_manage_bookings',
+        'menu_slug'   => 'rbf_tables',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Report & Analytics',
+        'menu_title'  => 'Report & Analytics',
+        'capability'  => 'rbf_manage_bookings',
+        'menu_slug'   => 'rbf_reports',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Notifiche Email',
+        'menu_title'  => 'Notifiche Email',
+        'capability'  => 'manage_options',
+        'menu_slug'   => 'rbf_email_notifications',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Esporta Dati',
+        'menu_title'  => 'Esporta Dati',
+        'capability'  => 'rbf_manage_bookings',
+        'menu_slug'   => 'rbf_export',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Impostazioni',
+        'menu_title'  => 'Impostazioni',
+        'capability'  => 'manage_options',
+        'menu_slug'   => 'rbf_settings',
+    ],
+    [
+        'parent_slug' => 'rbf_calendar',
+        'page_title'  => 'Validazione Tracking',
+        'menu_title'  => 'Validazione Tracking',
+        'capability'  => 'manage_options',
+        'menu_slug'   => 'rbf_tracking_validation',
+    ],
+];
+
+foreach ($expected_submenus as $expected) {
+    $found = false;
+    foreach ($GLOBALS['rbf_submenu_pages'] as $submenu) {
+        $matches = true;
+        foreach ($expected as $key => $value) {
+            if (($submenu[$key] ?? null) !== $value) {
+                $matches = false;
+                break;
+            }
+        }
+        if ($matches) {
+            $found = true;
+            break;
+        }
+    }
+
+    if (!$found) {
+        throw new RuntimeException(sprintf(
+            'Expected submenu "%s" was not registered.',
+            $expected['page_title']
+        ));
+    }
+}
+
+echo "Admin menu visibility test passed.\n";
+


### PR DESCRIPTION
## Summary
- add missing English translations for the new admin menu labels so they render correctly for all locales
- add a regression test that stubs WordPress helpers to ensure every required admin submenu is registered under “FP Prenotazioni Ristorante”

## Testing
- php -l includes/admin.php
- php -l includes/utils.php
- php tests/admin-menu-visibility-tests.php

------
https://chatgpt.com/codex/tasks/task_e_68d5389682d0832fb0fda07653e33252