### PR TITLE
Guard analytics chart data on settings page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Tutte le modifiche significative di **FP Prenotazioni Ristorante PRO** vengono documentate in questo file.
 Il formato segue l'approccio *Keep a Changelog* ed è coerente con la numerazione semantica introdotta dalla versione 1.x.
 
+## [1.6.1] – Aggiornamento Asset (2024)
+### Fixed
+- Incrementata la versione del plugin per forzare l'aggiornamento degli asset admin e rendere visibili le ultime ottimizzazioni grafiche e del filtro analytics.
+
 ## [1.6] – Documentazione Consolidata (2024)
 ### Added
 - Indice tematico della documentazione con collegamenti diretti alle singole guide specialistiche.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FP-Prenotazioni-Ristorante-PRO
 
-**Version:** 1.6  
+**Version:** 1.6.1
 **Author:** Francesco Passeri  
 **Website:** [francescopasseri.com](https://francescopasseri.com)  
 **Email:** [info@francescopasseri.com](mailto:info@francescopasseri.com)  

--- a/fp-prenotazioni-ristorante-pro.php
+++ b/fp-prenotazioni-ristorante-pro.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: FP Prenotazioni Ristorante
  * Description: Prenotazioni con calendario Flatpickr IT/EN, gestione capienza per servizio, notifiche email (con CC), Brevo sempre e GA4/Meta (bucket standard), con supporto ai limiti temporali minimi.
- * Version:     1.6
+ * Version:     1.6.1
  * Requires at least: 6.0
  * Tested up to: 6.5
  * Requires PHP: 7.4
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) {
 define('RBF_PLUGIN_FILE', __FILE__);
 define('RBF_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('RBF_PLUGIN_URL', plugin_dir_url(__FILE__));
-define('RBF_VERSION', '1.6');
+define('RBF_VERSION', '1.6.1');
 define('RBF_MIN_PHP_VERSION', '7.4');
 define('RBF_MIN_WP_VERSION', '6.0');
 

--- a/fppr-brand.json
+++ b/fppr-brand.json
@@ -7,7 +7,7 @@
   "border_radius": "8px",
   "logo_url": "",
   "brand_name": "",
-  "version": "1.6",
+  "version": "1.6.1",
   "_documentation": {
     "accent_color": "Primary brand color used for buttons, highlights, and focus states",
     "accent_color_light": "Lighter variant of accent color for hover states",

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1170,12 +1170,18 @@ function rbf_settings_page_html() {
     $meal_template_html = rbf_render_custom_meal_item('__INDEX__', [], $day_labels, true);
     ?>
     <script type="text/template" id="rbf-meal-template"><?php echo $meal_template_html; ?></script>
+    <?php
+    $analytics_by_status = $analytics['by_status'] ?? [];
+    $analytics_by_meal = $analytics['by_meal'] ?? [];
+    $analytics_daily_bookings = $analytics['daily_bookings'] ?? [];
+    $analytics_source_breakdown = $source_breakdown_values ?? [];
+    ?>
     <script>
     document.addEventListener('DOMContentLoaded', function() {
-        const statusData = <?php echo wp_json_encode($analytics['by_status']); ?>;
-        const mealData = <?php echo wp_json_encode($analytics['by_meal']); ?>;
-        const dailyData = <?php echo wp_json_encode($analytics['daily_bookings']); ?>;
-        const sourceBreakdown = <?php echo wp_json_encode($source_breakdown_values); ?>;
+        const statusData = <?php echo wp_json_encode($analytics_by_status); ?>;
+        const mealData = <?php echo wp_json_encode($analytics_by_meal); ?>;
+        const dailyData = <?php echo wp_json_encode($analytics_daily_bookings); ?>;
+        const sourceBreakdown = <?php echo wp_json_encode($analytics_source_breakdown); ?>;
 
         const statusCanvas = document.getElementById('statusChart');
         if (statusCanvas) {


### PR DESCRIPTION
## Summary
- guard the analytics chart bootstrapping data on the settings page so missing variables no longer trigger warnings

## Testing
- php -l includes/admin.php

------
https://chatgpt.com/codex/tasks/task_e_68d557c949bc832f8e2c422eb4b59adb