### PR TITLE
Bump plugin version to 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 Tutte le modifiche significative di **FP Prenotazioni Ristorante PRO** vengono documentate in questo file.
 Il formato segue l'approccio *Keep a Changelog* ed è coerente con la numerazione semantica introdotta dalla versione 1.x.
 
+## [1.6.3] – Allineamento Versione Distribuzione (2024)
+### Fixed
+- Incrementato il numero di versione del plugin e della documentazione per forzare il deploy delle ultime modifiche.
+
 ## [1.6.2] – Versionamento Automatico Asset (2024)
 ### Fixed
 - Calcolo della versione degli asset basato sull'ultima modifica del file per propagare immediatamente gli aggiornamenti senza dover incrementare manualmente la release.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FP-Prenotazioni-Ristorante-PRO
 
-**Version:** 1.6.2
+**Version:** 1.6.3
 **Author:** Francesco Passeri  
 **Website:** [francescopasseri.com](https://francescopasseri.com)  
 **Email:** [info@francescopasseri.com](mailto:info@francescopasseri.com)  

--- a/fp-prenotazioni-ristorante-pro.php
+++ b/fp-prenotazioni-ristorante-pro.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: FP Prenotazioni Ristorante
  * Description: Prenotazioni con calendario Flatpickr IT/EN, gestione capienza per servizio, notifiche email (con CC), Brevo sempre e GA4/Meta (bucket standard), con supporto ai limiti temporali minimi.
- * Version:     1.6.2
+ * Version:     1.6.3
  * Requires at least: 6.0
  * Tested up to: 6.5
  * Requires PHP: 7.4
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) {
 define('RBF_PLUGIN_FILE', __FILE__);
 define('RBF_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('RBF_PLUGIN_URL', plugin_dir_url(__FILE__));
-define('RBF_VERSION', '1.6.2');
+define('RBF_VERSION', '1.6.3');
 define('RBF_MIN_PHP_VERSION', '7.4');
 define('RBF_MIN_WP_VERSION', '6.0');
 

--- a/fppr-brand.json
+++ b/fppr-brand.json
@@ -7,7 +7,7 @@
   "border_radius": "8px",
   "logo_url": "",
   "brand_name": "",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "_documentation": {
     "accent_color": "Primary brand color used for buttons, highlights, and focus states",
     "accent_color_light": "Lighter variant of accent color for hover states",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: prenotazioni, ristorante, calendario, booking, marketing
 Requires at least: 6.0
 Tested up to: 6.5
 Requires PHP: 7.4
-Stable tag: 1.6.2
+Stable tag: 1.6.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- bump the plugin header and internal constants to version 1.6.3 so WordPress recognises the update
- sync the readme, README and brand metadata with the new release number
- document the release in the changelog to explain the distribution alignment

## Testing
- php -l fp-prenotazioni-ristorante-pro.php

------
https://chatgpt.com/codex/tasks/task_e_68d596d48558832f8bd0515b84d4a42e