### PR TITLE
Fix asset cache busting when query strings are stripped

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -830,18 +830,34 @@ function rbf_enqueue_admin_styles($hook) {
         return;
     }
 
+    $admin_css_url = rbf_get_versioned_asset_url('css/admin.css');
+    $admin_css_version = null;
+
+    if ($admin_css_url === '') {
+        $admin_css_url = plugin_dir_url(dirname(__FILE__)) . 'assets/css/admin.css';
+        $admin_css_version = rbf_get_asset_version('css/admin.css');
+    }
+
     wp_enqueue_style(
         'rbf-admin-css',
-        plugin_dir_url(dirname(__FILE__)) . 'assets/css/admin.css',
+        $admin_css_url,
         [],
-        rbf_get_asset_version('css/admin.css')
+        $admin_css_version
     );
+
+    $admin_js_url = rbf_get_versioned_asset_url('js/admin.js');
+    $admin_js_version = null;
+
+    if ($admin_js_url === '') {
+        $admin_js_url = plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin.js';
+        $admin_js_version = rbf_get_asset_version('js/admin.js');
+    }
 
     wp_register_script(
         'rbf-admin-js',
-        plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin.js',
+        $admin_js_url,
         ['jquery'],
-        rbf_get_asset_version('js/admin.js'),
+        $admin_js_version,
         true
     );
 
@@ -881,11 +897,19 @@ function rbf_enqueue_admin_styles($hook) {
 
         $fonts_catalog_admin = rbf_get_supported_brand_fonts();
 
+        $branding_js_url = rbf_get_versioned_asset_url('js/admin-branding.js');
+        $branding_js_version = null;
+
+        if ($branding_js_url === '') {
+            $branding_js_url = plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin-branding.js';
+            $branding_js_version = rbf_get_asset_version('js/admin-branding.js');
+        }
+
         wp_enqueue_script(
             'rbf-brand-admin',
-            plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin-branding.js',
+            $branding_js_url,
             ['jquery', 'wp-color-picker'],
-            rbf_get_asset_version('js/admin-branding.js'),
+            $branding_js_version,
             true
         );
 
@@ -2129,11 +2153,19 @@ function rbf_calendar_page_html() {
     rbf_enqueue_fullcalendar_assets();
 
     if (!wp_script_is('rbf-admin-js', 'registered')) {
+        $admin_js_url = rbf_get_versioned_asset_url('js/admin.js');
+        $admin_js_version = null;
+
+        if ($admin_js_url === '') {
+            $admin_js_url = plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin.js';
+            $admin_js_version = rbf_get_asset_version('js/admin.js');
+        }
+
         wp_register_script(
             'rbf-admin-js',
-            plugin_dir_url(dirname(__FILE__)) . 'assets/js/admin.js',
+            $admin_js_url,
             ['jquery'],
-            rbf_get_asset_version('js/admin.js'),
+            $admin_js_version,
             true
         );
     }
@@ -2163,11 +2195,19 @@ function rbf_weekly_staff_page_html() {
     }
 
     rbf_enqueue_fullcalendar_assets();
+    $weekly_staff_js_url = rbf_get_versioned_asset_url('js/weekly-staff.js');
+    $weekly_staff_js_version = null;
+
+    if ($weekly_staff_js_url === '') {
+        $weekly_staff_js_url = plugin_dir_url(dirname(__FILE__)) . 'assets/js/weekly-staff.js';
+        $weekly_staff_js_version = rbf_get_asset_version('js/weekly-staff.js');
+    }
+
     wp_enqueue_script(
         'rbf-weekly-staff-js',
-        plugin_dir_url(dirname(__FILE__)) . 'assets/js/weekly-staff.js',
+        $weekly_staff_js_url,
         ['jquery', 'fullcalendar-js'],
-        rbf_get_asset_version('js/weekly-staff.js'),
+        $weekly_staff_js_version,
         true
     );
 

--- a/includes/frontend.php
+++ b/includes/frontend.php
@@ -92,20 +92,36 @@ function rbf_enqueue_frontend_assets() {
     }
 
     // Frontend styles and brand variables
+    $frontend_css_url = rbf_get_versioned_asset_url('css/frontend.css');
+    $frontend_css_version = null;
+
+    if ($frontend_css_url === '') {
+        $frontend_css_url = rbf_get_asset_url('css/frontend.css');
+        $frontend_css_version = rbf_get_asset_version('css/frontend.css');
+    }
+
     wp_enqueue_style(
         'rbf-frontend-css',
-        rbf_get_asset_url('css/frontend.css'),
+        $frontend_css_url,
         ['rbf-flatpickr-css'],
-        rbf_get_asset_version('css/frontend.css')
+        $frontend_css_version
     );
     rbf_inject_brand_css_vars();
 
     // Register frontend script before attaching inline fallbacks
+    $frontend_js_url = rbf_get_versioned_asset_url('js/frontend.js');
+    $frontend_js_version = null;
+
+    if ($frontend_js_url === '') {
+        $frontend_js_url = rbf_get_asset_url('js/frontend.js');
+        $frontend_js_version = rbf_get_asset_version('js/frontend.js');
+    }
+
     wp_register_script(
         'rbf-frontend-js',
-        rbf_get_asset_url('js/frontend.js'),
+        $frontend_js_url,
         $deps,
-        rbf_get_asset_version('js/frontend.js'),
+        $frontend_js_version,
         true
     );
 


### PR DESCRIPTION
## Summary
- add a dedicated helper that appends an `rbf_ver` query parameter based on the asset hash so cache busting survives plugins that strip the default `ver` argument
- use the new helper for all admin and frontend CSS/JS loads, keeping legacy behaviour as a fallback when the helper cannot resolve an URL

## Testing
- `./validate-fix.sh`


------
https://chatgpt.com/codex/tasks/task_e_68d64a0f4a98832fbdcac1c4742bde63